### PR TITLE
standardize font types for headings and body text in md_to_docx tool

### DIFF
--- a/tools/md_to_docx/md_to_docx.py
+++ b/tools/md_to_docx/md_to_docx.py
@@ -72,30 +72,27 @@ class MarkdownToDocxTool(Tool):
 
     def set_fonts_for_all_runs(self, doc: Document):
         """Set Times New Roman for English text and SimSun for Chinese text in all text elements."""
+        def apply_fonts_to_run(run):
+            if not run.text.strip():  # Skip empty text
+                return
+            # Set default font to Times New Roman
+            run.font.name = 'Times New Roman'
+            # Set East Asian font to SimSun
+            run._element.rPr.rFonts.set(qn('w:eastAsia'), '宋体')
+            # Set ASCII font to Times New Roman
+            run._element.rPr.rFonts.set(qn('w:ascii'), 'Times New Roman')
+            # Set high ANSI font to Times New Roman
+            run._element.rPr.rFonts.set(qn('w:hAnsi'), 'Times New Roman')
+
+        # Process all paragraphs in the document
         for paragraph in doc.paragraphs:
             for run in paragraph.runs:
-                if run.text.strip():  # Skip empty text
-                    # Set default font to Times New Roman
-                    run.font.name = 'Times New Roman'
-                    # Set East Asian font to SimSun
-                    run._element.rPr.rFonts.set(qn('w:eastAsia'), '宋体')
-                    # Set ASCII font to Times New Roman
-                    run._element.rPr.rFonts.set(qn('w:ascii'), 'Times New Roman')
-                    # Set high ANSI font to Times New Roman
-                    run._element.rPr.rFonts.set(qn('w:hAnsi'), 'Times New Roman')
+                apply_fonts_to_run(run)
 
-        # Process tables
+        # Process all paragraphs in tables
         for table in doc.tables:
             for row in table.rows:
                 for cell in row.cells:
                     for paragraph in cell.paragraphs:
                         for run in paragraph.runs:
-                            if run.text.strip():  # Skip empty text
-                                # Set default font to Times New Roman
-                                run.font.name = 'Times New Roman'
-                                # Set East Asian font to SimSun
-                                run._element.rPr.rFonts.set(qn('w:eastAsia'), '宋体')
-                                # Set ASCII font to Times New Roman
-                                run._element.rPr.rFonts.set(qn('w:ascii'), 'Times New Roman')
-                                # Set high ANSI font to Times New Roman
-                                run._element.rPr.rFonts.set(qn('w:hAnsi'), 'Times New Roman')
+                            apply_fonts_to_run(run)

--- a/tools/md_to_docx/md_to_docx.py
+++ b/tools/md_to_docx/md_to_docx.py
@@ -37,7 +37,7 @@ class MarkdownToDocxTool(Tool):
             new_parser = HtmlToDocx()
             doc: Document = new_parser.parse_html_string(html)
 
-            # 为所有文本设置字体
+            # Set fonts for all text elements
             self.set_fonts_for_all_runs(doc)
 
             result_bytes_io = io.BytesIO()
@@ -71,31 +71,31 @@ class MarkdownToDocxTool(Tool):
         rPr.rFonts.set(qn('w:eastAsia'), '宋体')
 
     def set_fonts_for_all_runs(self, doc: Document):
-        """为所有文本段落设置英文字体为 Times New Roman，中文字体为宋体。"""
+        """Set Times New Roman for English text and SimSun for Chinese text in all text elements."""
         for paragraph in doc.paragraphs:
             for run in paragraph.runs:
-                if run.text.strip():  # 只处理非空文本
-                    # 设置默认字体为 Times New Roman
+                if run.text.strip():  # Skip empty text
+                    # Set default font to Times New Roman
                     run.font.name = 'Times New Roman'
-                    # 设置东亚字体为宋体
+                    # Set East Asian font to SimSun
                     run._element.rPr.rFonts.set(qn('w:eastAsia'), '宋体')
-                    # 设置 ASCII 字体为 Times New Roman
+                    # Set ASCII font to Times New Roman
                     run._element.rPr.rFonts.set(qn('w:ascii'), 'Times New Roman')
-                    # 设置高 ANSI 字体为 Times New Roman
+                    # Set high ANSI font to Times New Roman
                     run._element.rPr.rFonts.set(qn('w:hAnsi'), 'Times New Roman')
 
-        # 同时处理表格
+        # Process tables
         for table in doc.tables:
             for row in table.rows:
                 for cell in row.cells:
                     for paragraph in cell.paragraphs:
                         for run in paragraph.runs:
-                            if run.text.strip():  # 只处理非空文本
-                                # 设置默认字体为 Times New Roman
+                            if run.text.strip():  # Skip empty text
+                                # Set default font to Times New Roman
                                 run.font.name = 'Times New Roman'
-                                # 设置东亚字体为宋体
+                                # Set East Asian font to SimSun
                                 run._element.rPr.rFonts.set(qn('w:eastAsia'), '宋体')
-                                # 设置 ASCII 字体为 Times New Roman
+                                # Set ASCII font to Times New Roman
                                 run._element.rPr.rFonts.set(qn('w:ascii'), 'Times New Roman')
-                                # 设置高 ANSI 字体为 Times New Roman
+                                # Set high ANSI font to Times New Roman
                                 run._element.rPr.rFonts.set(qn('w:hAnsi'), 'Times New Roman')

--- a/tools/md_to_docx/md_to_docx.py
+++ b/tools/md_to_docx/md_to_docx.py
@@ -37,8 +37,8 @@ class MarkdownToDocxTool(Tool):
             new_parser = HtmlToDocx()
             doc: Document = new_parser.parse_html_string(html)
 
-            if self.is_contains_chinese_chars(html):
-                self.set_chinese_fonts(doc)
+            # 为所有文本设置字体
+            self.set_fonts_for_all_runs(doc)
 
             result_bytes_io = io.BytesIO()
             doc.save(result_bytes_io)
@@ -69,3 +69,33 @@ class MarkdownToDocxTool(Tool):
         font.name = 'Times New Roman'
         rPr = style.element.get_or_add_rPr()
         rPr.rFonts.set(qn('w:eastAsia'), '宋体')
+
+    def set_fonts_for_all_runs(self, doc: Document):
+        """为所有文本段落设置英文字体为 Times New Roman，中文字体为宋体。"""
+        for paragraph in doc.paragraphs:
+            for run in paragraph.runs:
+                if run.text.strip():  # 只处理非空文本
+                    # 设置默认字体为 Times New Roman
+                    run.font.name = 'Times New Roman'
+                    # 设置东亚字体为宋体
+                    run._element.rPr.rFonts.set(qn('w:eastAsia'), '宋体')
+                    # 设置 ASCII 字体为 Times New Roman
+                    run._element.rPr.rFonts.set(qn('w:ascii'), 'Times New Roman')
+                    # 设置高 ANSI 字体为 Times New Roman
+                    run._element.rPr.rFonts.set(qn('w:hAnsi'), 'Times New Roman')
+
+        # 同时处理表格
+        for table in doc.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    for paragraph in cell.paragraphs:
+                        for run in paragraph.runs:
+                            if run.text.strip():  # 只处理非空文本
+                                # 设置默认字体为 Times New Roman
+                                run.font.name = 'Times New Roman'
+                                # 设置东亚字体为宋体
+                                run._element.rPr.rFonts.set(qn('w:eastAsia'), '宋体')
+                                # 设置 ASCII 字体为 Times New Roman
+                                run._element.rPr.rFonts.set(qn('w:ascii'), 'Times New Roman')
+                                # 设置高 ANSI 字体为 Times New Roman
+                                run._element.rPr.rFonts.set(qn('w:hAnsi'), 'Times New Roman')


### PR DESCRIPTION
- to fix #51 
修复了在 Markdown 转 Docx 中 只对正文设置字体的问题，使Docx中的标题与正文统一使用 宋体 与 Times New Roman。
fix: apply consistent fonts (SimSun & Times New Roman) to both headings and body in Markdown-to-DOCX conversion.