### PR TITLE
Fixed an issue where filenames were not displayed correctly in self-hosted Dify

### DIFF
--- a/tools/utils/file_utils.py
+++ b/tools/utils/file_utils.py
@@ -20,4 +20,5 @@ def get_meta_data(mime_type: MimeType, output_filename: Optional[str]) -> dict[s
     return {
         "mime_type": mime_type,
         "filename": result_filename,
+        "file_name": result_filename
     }


### PR DESCRIPTION
## Issue
  - Self-hosted Dify v1.4.0 requires `file_name` field in metadata
  - Current code only returns `filename` field, causing filenames not to be displayed in self-hosted environments

## Changes
  - Added `file_name` field to the return value of `get_meta_data` function
  - Now compatible with both Dify Cloud (uses `filename`) and self-hosted Dify (uses `file_name`)

## Impact
  - No impact on existing Dify Cloud environments (`filename` field is maintained)
  - Filenames will now be displayed correctly in self-hosted Dify

## Testing
  - Verified working on self-hosted Dify v1.4.0