### PR TITLE
Introduce md_to_mermaid tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ With support for **15+ output formats**, Markdown Exporter bridges the gap betwe
     <td>🖼️ <a href="https://www.markdownguide.org/basic-syntax/#linking-images">Image links in Markdown</a> </td>
     <td>🖼️ Downloaded image files</td>
   </tr>
+  <tr>
+    <td><code>md_to_mermaid</code></td>
+    <td>📊 <a href="https://mermaid.js.org/">Mermaid diagrams in Markdown</a> </td>
+    <td>🖼️ PNG image(s) of Mermaid diagrams</td>
+  </tr>
 </table>
 
 ---
@@ -266,7 +271,31 @@ Automatically download all images referenced in your Markdown.
 
 ---
 
-### 📋 Markdown → CSV
+### � Markdown → Mermaid Diagrams
+
+Convert Mermaid diagram code blocks in your Markdown to beautiful PNG images.
+
+
+
+**Input Example:**
+```markdown
+```mermaid
+graph TD
+    A[Start] --> B[Process]
+    B --> C[Decision]
+    C -->|Yes| D[Success]
+    C -->|No| E[Failure]
+    D --> F[End]
+    E --> F
+```
+```
+
+**Output:**
+PNG images of your Mermaid diagrams, ready to use in presentations, reports, or documentation.
+
+---
+
+### �📋 Markdown → CSV
 
 Export your Markdown tables to universal CSV format.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,6 +86,11 @@ disable: false
     <td>🖼️ <a href="https://www.markdownguide.org/basic-syntax/#linking-images">Image links in Markdown</a> </td>
     <td>🖼️ Downloaded image files</td>
   </tr>
+  <tr>
+    <td><code>md_to_mermaid</code></td>
+    <td>📊 <a href="https://mermaid.js.org/">Mermaid diagrams in Markdown</a> </td>
+    <td>🖼️ PNG image(s) of Mermaid diagrams</td>
+  </tr>
 </table>
 
 ## Prerequisites
@@ -445,6 +450,30 @@ scripts/bin/md_to_linked_image.sh <input> <output> [options]
 ```bash
 scripts/bin/md_to_linked_image.sh /path/input.md /path/output_dir
 scripts/bin/md_to_linked_image.sh /path/input.md /path/output.zip --compress
+```
+
+
+### md_to_mermaid - Convert Mermaid Diagrams to PNG
+
+Converts Mermaid diagram code blocks in Markdown to PNG images.
+
+**Usage:**
+```bash
+scripts/bin/md_to_mermaid.sh <input> <output> [options]
+```
+
+**Arguments:**
+- `input` - Input Markdown file path or Markdown text
+- `output` - Output PNG file path or directory path
+
+**Options:**
+- `--compress` - Compress all PNG images into a ZIP file
+- `--strip-wrapper` - Remove code block wrapper if present
+
+**Example:**
+```bash
+scripts/bin/md_to_mermaid.sh /path/input.md /path/output.png
+scripts/bin/md_to_mermaid.sh /path/input.md /path/output.zip --compress
 ```
 
 

--- a/provider/md_exporter.py
+++ b/provider/md_exporter.py
@@ -12,6 +12,7 @@ from tools.md_to_json.md_to_json import MarkdownToJsonTool
 from tools.md_to_latex.md_to_latex import MarkdownToLatexTool
 from tools.md_to_linked_image.md_to_linked_image import MarkdownToLinkedImageTool
 from tools.md_to_md.md_to_md import MarkdownToMarkdownTool
+from tools.md_to_mermaid.md_to_mermaid import MarkdownToMermaidTool
 from tools.md_to_pdf.md_to_pdf import MarkdownToPdfTool
 from tools.md_to_png.md_to_png import MarkdownToPngTool
 from tools.md_to_pptx.md_to_pptx import MarkdownToPptxTool
@@ -40,6 +41,7 @@ class MdExporterProvider(ToolProvider):
                 MarkdownToPptxTool,
                 MarkdownToXlsxTool,
                 MarkdownToXmlTool,
+                MarkdownToMermaidTool,
             ]
             for tool in tools:
                 tool.from_credentials({})

--- a/provider/md_exporter.yaml
+++ b/provider/md_exporter.yaml
@@ -25,6 +25,7 @@ tools:
   - tools/md_to_latex/md_to_latex.yaml
   - tools/md_to_codeblock/md_to_codeblock.yaml
   - tools/md_to_linked_image/md_to_linked_image.yaml
+  - tools/md_to_mermaid/md_to_mermaid.yaml
 extra:
   python:
     source: provider/md_exporter.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "PyMuPDF~=1.26.4",
     "pillow~=12.0.0",
     "pypandoc-binary~=1.16.2",
+    "nodejs-wheel-binaries>=20.13.0",
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,9 @@ python-pptx~=1.0.2
 PyMuPDF~=1.26.4
 pillow~=12.0.0
 
+# for markdown to mermaid
+nodejs-wheel-binaries>=20.13.0
+
 # pandoc
 pypandoc-binary~=1.16.2
 

--- a/scripts/bin/md_to_mermaid.sh
+++ b/scripts/bin/md_to_mermaid.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Import common script
+source "$(dirname "${BASH_SOURCE[0]}")/script_runner.sh"
+
+# Run Python script
+run_python_script "md_to_mermaid.py" "$@"

--- a/scripts/md_to_codeblock.py
+++ b/scripts/md_to_codeblock.py
@@ -17,7 +17,7 @@ if script_dir not in sys.path:
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-from services.svc_md_to_codeblock import convert_md_to_codeblock
+from services.svc_md_to_codeblock import convert_md_to_codeblock  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_csv.py
+++ b/scripts/md_to_csv.py
@@ -18,7 +18,7 @@ if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
 # Import shared utility functions
-from services.svc_md_to_csv import convert_md_to_csv
+from services.svc_md_to_csv import convert_md_to_csv  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_docx.py
+++ b/scripts/md_to_docx.py
@@ -18,7 +18,7 @@ if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
 # Import shared utility functions
-from services.svc_md_to_docx import convert_md_to_docx, get_default_template
+from services.svc_md_to_docx import convert_md_to_docx, get_default_template  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_html.py
+++ b/scripts/md_to_html.py
@@ -18,7 +18,7 @@ if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
 # Import shared utility functions
-from services.svc_md_to_html import convert_md_to_html
+from services.svc_md_to_html import convert_md_to_html  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_html_text.py
+++ b/scripts/md_to_html_text.py
@@ -17,7 +17,7 @@ if script_dir not in sys.path:
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-from services.svc_md_to_html_text import convert_md_to_html_text
+from services.svc_md_to_html_text import convert_md_to_html_text  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_json.py
+++ b/scripts/md_to_json.py
@@ -17,7 +17,7 @@ if script_dir not in sys.path:
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-from services.svc_md_to_json import convert_md_to_json
+from services.svc_md_to_json import convert_md_to_json  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_latex.py
+++ b/scripts/md_to_latex.py
@@ -17,7 +17,7 @@ if script_dir not in sys.path:
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-from services.svc_md_to_latex import convert_md_to_latex
+from services.svc_md_to_latex import convert_md_to_latex  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_linked_image.py
+++ b/scripts/md_to_linked_image.py
@@ -17,7 +17,7 @@ if script_dir not in sys.path:
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-from services.svc_md_to_linked_image import convert_md_to_linked_image
+from services.svc_md_to_linked_image import convert_md_to_linked_image  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_md.py
+++ b/scripts/md_to_md.py
@@ -17,7 +17,7 @@ if script_dir not in sys.path:
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-from services.svc_md_to_md import convert_md_to_md
+from services.svc_md_to_md import convert_md_to_md  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_mermaid.py
+++ b/scripts/md_to_mermaid.py
@@ -3,8 +3,8 @@
 Convert Markdown text to mermaid SVG files
 """
 
-import sys
 import os
+import sys
 
 # Add current directory to Python path
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))

--- a/scripts/md_to_mermaid.py
+++ b/scripts/md_to_mermaid.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Convert Markdown text to mermaid SVG files
+"""
+
+import sys
+import os
+
+# Add current directory to Python path
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from pathlib import Path
+
+from scripts.services.svc_md_to_mermaid import convert_md_to_mermaid
+
+
+def main():
+    """
+    Main function
+    """
+    if len(sys.argv) < 2:
+        print("Usage: python md_to_mermaid.py <markdown_file> [output_path] [--compress]")
+        sys.exit(1)
+
+    # Get input file path
+    input_file = Path(sys.argv[1])
+    if not input_file.exists():
+        print(f"Error: Input file not found: {input_file}")
+        sys.exit(1)
+
+    # Read markdown text
+    md_text = input_file.read_text()
+
+    # Get output path
+    output_path = Path("output")
+    if len(sys.argv) > 2:
+        output_path = Path(sys.argv[2])
+
+    # Check if compress flag is set
+    compress = False
+    if len(sys.argv) > 3 and sys.argv[3] == "--compress":
+        compress = True
+
+    try:
+        # Convert markdown to mermaid SVGs
+        created_files = convert_md_to_mermaid(md_text, output_path, compress=compress)
+        print(f"Successfully created {len(created_files)} files:")
+        for file_path in created_files:
+            print(f"  - {file_path}")
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/md_to_mermaid.py
+++ b/scripts/md_to_mermaid.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Convert Markdown text to mermaid SVG files
+Convert Markdown text to mermaid PNG files
 """
 
 import os
@@ -42,7 +42,7 @@ def main():
         compress = True
 
     try:
-        # Convert markdown to mermaid SVGs
+        # Convert markdown to mermaid PNG images
         created_files = convert_md_to_mermaid(md_text, output_path, compress=compress)
         print(f"Successfully created {len(created_files)} files:")
         for file_path in created_files:

--- a/scripts/md_to_pdf.py
+++ b/scripts/md_to_pdf.py
@@ -18,7 +18,7 @@ if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
 # Import shared utility functions
-from services.svc_md_to_pdf import convert_md_to_pdf
+from services.svc_md_to_pdf import convert_md_to_pdf  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_png.py
+++ b/scripts/md_to_png.py
@@ -17,7 +17,7 @@ if script_dir not in sys.path:
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-from services.svc_md_to_png import convert_md_to_png
+from services.svc_md_to_png import convert_md_to_png  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_pptx.py
+++ b/scripts/md_to_pptx.py
@@ -17,7 +17,7 @@ if script_dir not in sys.path:
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-from services.svc_md_to_pptx import convert_md_to_pptx
+from services.svc_md_to_pptx import convert_md_to_pptx  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_xlsx.py
+++ b/scripts/md_to_xlsx.py
@@ -18,7 +18,7 @@ if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
 # Import shared utility functions
-from services.svc_md_to_xlsx import convert_md_to_xlsx
+from services.svc_md_to_xlsx import convert_md_to_xlsx  # noqa: E402
 
 
 def main():

--- a/scripts/md_to_xml.py
+++ b/scripts/md_to_xml.py
@@ -17,7 +17,7 @@ if script_dir not in sys.path:
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-from services.svc_md_to_xml import convert_md_to_xml
+from services.svc_md_to_xml import convert_md_to_xml  # noqa: E402
 
 
 def main():

--- a/scripts/services/svc_md_to_mermaid.py
+++ b/scripts/services/svc_md_to_mermaid.py
@@ -23,7 +23,8 @@ def pre_install_mermaid():
     """
     try:
         # Execute npx command to install mermaid-cli
-        cmd_args = ["--yes", "-p", "@mermaid-js/mermaid-cli", "-h"]
+        cmd_args = ["--yes", "--package", "@mermaid-js/mermaid-cli",
+                    "mmdc", "-V"]
         print("Pre-installing mermaid-cli...")
         result = npx(cmd_args, return_completed_process=True)
         print("Mermaid-cli pre-installation completed successfully")
@@ -96,7 +97,7 @@ def convert_mermaid_to_png(mermaid_code: str, output_path: Path) -> bool:
             print("Using nodejs-wheel npx")
             
             # Command arguments for mermaid-cli
-            cmd_args = ["--yes", "-p", "@mermaid-js/mermaid-cli",
+            cmd_args = ["--yes", "--package", "@mermaid-js/mermaid-cli",
                         "mmdc",
                         "-i", str(temp_mermaid_path),
                         "-o", str(output_path),

--- a/scripts/services/svc_md_to_mermaid.py
+++ b/scripts/services/svc_md_to_mermaid.py
@@ -4,7 +4,6 @@ MdToMermaid service
 """
 
 import re
-import subprocess
 import sys
 import zipfile
 from pathlib import Path
@@ -12,7 +11,6 @@ from subprocess import CalledProcessError
 from tempfile import NamedTemporaryFile
 
 from nodejs_wheel import npx
-
 
 from scripts.utils.markdown_utils import get_md_text
 

--- a/scripts/services/svc_md_to_mermaid.py
+++ b/scripts/services/svc_md_to_mermaid.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+MdToMermaid service
+"""
+
+import re
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from subprocess import CalledProcessError
+from tempfile import NamedTemporaryFile
+
+# Try to import nodejs-wheel-binaries
+# If it fails, we'll use system npx
+try:
+    from nodejs_wheel import npx
+    has_nodejs_wheel = True
+except ImportError:
+    print("Warning: nodejs-wheel-binaries not installed. Using system npx instead.", file=sys.stderr)
+    npx = None
+    has_nodejs_wheel = False
+
+from scripts.utils.markdown_utils import get_md_text
+
+
+def extract_mermaid_blocks(md_text: str) -> list[str]:
+    """
+    Extract mermaid code blocks from Markdown text
+    Args:
+        md_text: Markdown text to process
+    Returns:
+        List of mermaid code blocks
+    """
+    # Pattern to match mermaid code blocks
+    mermaid_pattern = re.compile(r'```mermaid\n(.*?)```', re.DOTALL)
+    mermaid_blocks = mermaid_pattern.findall(md_text)
+
+    # Clean up code blocks
+    cleaned_blocks = []
+    for block in mermaid_blocks:
+        # Remove leading/trailing whitespace
+        cleaned_block = block.strip()
+        if cleaned_block:
+            cleaned_blocks.append(cleaned_block)
+
+    return cleaned_blocks
+
+
+def convert_mermaid_to_png(mermaid_code: str, output_path: Path) -> bool:
+    """
+    Convert mermaid code to PNG using mermaid-cli
+    Args:
+        mermaid_code: Mermaid code to convert
+        output_path: Path to save the PNG output
+    Returns:
+        True if conversion succeeded, False otherwise
+    """
+
+    try:
+        # Create a temporary file for mermaid code (without markdown wrapper)
+        # Mermaid CLI can process plain mermaid code files
+        with NamedTemporaryFile(suffix=".mmd", delete=False) as temp_mermaid_file:
+            temp_mermaid_path = Path(temp_mermaid_file.name)
+            temp_mermaid_path.write_text(mermaid_code)
+
+        print(f"Created temporary file with content:\n{mermaid_code}")
+
+        # Execute mermaid-cli command
+        print(f"Executing mermaid-cli command for file: {temp_mermaid_path}")
+        
+        # Try different approaches to execute mermaid-cli
+        approaches = [
+            # Approach 1: Use system npx (most reliable)
+            {
+                "name": "system npx",
+                "command": ["npx", "--yes", "-p", "@mermaid-js/mermaid-cli", "mmdc", "-i", str(temp_mermaid_path), "-o", str(output_path)],
+                "use_subprocess": True
+            },
+            # Approach 2: Use nodejs-wheel npx if available
+            {
+                "name": "nodejs-wheel npx",
+                "command": ["--yes", "-p", "@mermaid-js/mermaid-cli", "mmdc", "-i", str(temp_mermaid_path), "-o", str(output_path)],
+                "use_subprocess": False
+            }
+        ]
+        
+        success = False
+        
+        for approach in approaches:
+            try:
+                print(f"\nTrying approach: {approach['name']}")
+                
+                if approach['use_subprocess']:
+                    # Use subprocess to execute system npx
+                    cmd = approach['command']
+                    print(f"Running command: {' '.join(cmd)}")
+                    
+                    # Set environment variables to avoid Puppeteer issues
+                    import os
+                    env = os.environ.copy()
+                    env["PUPPETEER_SKIP_CHROMIUM_DOWNLOAD"] = "true"
+                    
+                    # Execute the command
+                    result = subprocess.run(
+                        cmd,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                        timeout=60,  # Increase timeout to 60 seconds
+                        env=env
+                    )
+                    
+                    print(f"Command returned: {result.returncode}")
+                    print(f"stdout: {result.stdout}")
+                    print(f"stderr: {result.stderr}")
+                    
+                else:
+                    # Use nodejs-wheel npx if available
+                    if not has_nodejs_wheel:
+                        print("Skipping approach: nodejs-wheel not available", file=sys.stderr)
+                        continue
+                    
+                    cmd_args = approach['command']
+                    print(f"Running command: npx {' '.join(cmd_args)}")
+                    
+                    # Execute the command
+                    result = npx(cmd_args, return_completed_process=True)
+                    
+                    print(f"Command returned: {result}")
+                
+                # Check if output file exists and has content
+                if output_path.exists() and output_path.stat().st_size > 0:
+                    print(f"Success with approach: {approach['name']}")
+                    print(f"Output file size: {output_path.stat().st_size} bytes")
+                    success = True
+                    break
+                else:
+                    print(f"Output file not created or empty with approach: {approach['name']}")
+                    # Clean up empty output file
+                    if output_path.exists():
+                        output_path.unlink()
+                        
+            except Exception as e:
+                print(f"Error with approach {approach['name']}: {e}", file=sys.stderr)
+                # Clean up empty output file
+                if output_path.exists():
+                    output_path.unlink()
+                continue
+        
+        if not success:
+            print("Error: All approaches failed to convert mermaid code to PNG", file=sys.stderr)
+            return False
+
+        # Output file should exist and have content since we checked it in the loop
+        print(f"Successfully converted mermaid code to PNG: {output_path}")
+        print(f"Output file size: {output_path.stat().st_size} bytes")
+        return True
+
+    except CalledProcessError as e:
+        print(f"Error: mermaid-cli execution failed: {e}", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"Error: Unexpected error during conversion: {e}", file=sys.stderr)
+        return False
+    finally:
+        # Clean up temporary files
+        if 'temp_mermaid_path' in locals() and temp_mermaid_path.exists():
+            try:
+                temp_mermaid_path.unlink()
+            except Exception:
+                pass
+
+
+def convert_md_to_mermaid(md_text: str, output_path: Path, compress: bool = False,
+                          is_strip_wrapper: bool = False) -> list[Path]:
+    """
+    Extract mermaid code blocks from Markdown and convert them to PNG files
+    Args:
+        md_text: Markdown text to process
+        output_path: Path to save the output files
+        compress: Whether to compress all PNGs into a ZIP file
+        is_strip_wrapper: Whether to remove code block wrapper if present
+    Returns:
+        List of paths to the created files
+    Raises:
+        ValueError: If input processing fails
+        Exception: If conversion fails
+    """
+    # Process Markdown text
+    processed_md = get_md_text(md_text, is_strip_wrapper=is_strip_wrapper)
+
+    # Extract mermaid code blocks
+    mermaid_blocks = extract_mermaid_blocks(processed_md)
+
+    if not mermaid_blocks:
+        raise ValueError("No mermaid code blocks found in the input text")
+
+    # Convert each mermaid block to PNG
+    png_files = []
+    for i, mermaid_code in enumerate(mermaid_blocks):
+        try:
+            # Create temporary PNG file
+            with NamedTemporaryFile(suffix=".png", delete=False) as temp_png_file:
+                temp_png_path = Path(temp_png_file.name)
+
+            # Convert mermaid to PNG
+            success = convert_mermaid_to_png(mermaid_code, temp_png_path)
+            if success:
+                png_files.append(temp_png_path)
+                print(f"Converted mermaid diagram {i + 1}")
+            else:
+                print(f"Failed to convert mermaid diagram {i + 1}", file=sys.stderr)
+                # Clean up failed conversion
+                if temp_png_path.exists():
+                    temp_png_path.unlink()
+
+        except Exception as e:
+            print(f"Error converting mermaid diagram {i + 1}: {e}", file=sys.stderr)
+            # Clean up temporary files
+            if 'temp_png_path' in locals() and temp_png_path.exists():
+                try:
+                    temp_png_path.unlink()
+                except Exception:
+                    pass
+
+    if not png_files:
+        raise Exception("No mermaid diagrams were successfully converted")
+
+    # Output files
+    created_files = []
+    if compress:
+        # Compress to ZIP file
+        try:
+            with NamedTemporaryFile(suffix=".zip", delete=False) as temp_zip_file:
+                temp_zip_path = Path(temp_zip_file.name)
+
+            with zipfile.ZipFile(temp_zip_path, mode='w', compression=zipfile.ZIP_DEFLATED) as zip_file:
+                for i, png_path in enumerate(png_files):
+                    zip_file.write(png_path, arcname=f"mermaid_{i + 1}.png")
+
+            # Copy to final output path
+            output_path.write_bytes(temp_zip_path.read_bytes())
+            created_files.append(output_path)
+            print(f"Successfully created ZIP file with {len(png_files)} PNG diagrams: {output_path}")
+
+            # Clean up temporary files
+            temp_zip_path.unlink()
+            for png_path in png_files:
+                png_path.unlink()
+
+        except Exception as e:
+            # Clean up temporary files
+            if 'temp_zip_path' in locals() and temp_zip_path.exists():
+                temp_zip_path.unlink()
+            for png_path in png_files:
+                if png_path.exists():
+                    png_path.unlink()
+            raise Exception(f"Failed to create ZIP file: {e}")
+    else:
+        # Save as separate files
+        try:
+            # If output path is a directory, create directory
+            if output_path.suffix == '':
+                output_path.mkdir(parents=True, exist_ok=True)
+                base_path = output_path
+            else:
+                # If output path is a file, use parent directory as base path
+                base_path = output_path.parent
+
+            for i, png_path in enumerate(png_files):
+                if len(png_files) > 1:
+                    file_path = base_path / f"{output_path.stem}_{i + 1}.png"
+                else:
+                    file_path = output_path if output_path.suffix == '.png' else base_path / f"{output_path.name}.png"
+
+                file_path.parent.mkdir(parents=True, exist_ok=True)
+                # Copy PNG content
+                file_path.write_bytes(png_path.read_bytes())
+                created_files.append(file_path)
+                print(f"Successfully saved PNG to {file_path}")
+
+                # Clean up temporary file
+                png_path.unlink()
+
+        except Exception as e:
+            # Clean up temporary files
+            for png_path in png_files:
+                if png_path.exists():
+                    png_path.unlink()
+            raise Exception(f"Failed to save PNG files: {e}")
+
+    return created_files

--- a/scripts/services/svc_md_to_mermaid.py
+++ b/scripts/services/svc_md_to_mermaid.py
@@ -52,7 +52,7 @@ def convert_mermaid_to_png(mermaid_code: str, output_path: Path) -> bool:
 
     try:
         # Create a temporary file for mermaid code (without markdown wrapper)
-        # Mermaid CLI can process plain mermaid code files
+        # Mermaid CLI can process plain mermaid code files with .mmd extension
         with NamedTemporaryFile(suffix=".mmd", delete=False) as temp_mermaid_file:
             temp_mermaid_path = Path(temp_mermaid_file.name)
             temp_mermaid_path.write_text(mermaid_code)
@@ -68,7 +68,12 @@ def convert_mermaid_to_png(mermaid_code: str, output_path: Path) -> bool:
             print("Using nodejs-wheel npx")
             
             # Command arguments for mermaid-cli
-            cmd_args = ["--yes", "-p", "@mermaid-js/mermaid-cli", "mmdc", "-i", str(temp_mermaid_path), "-o", str(output_path)]
+            cmd_args = ["--yes", "-p", "@mermaid-js/mermaid-cli",
+                        "mmdc",
+                        "-i", str(temp_mermaid_path),
+                        "-o", str(output_path),
+                        "--scale", "2",
+                        ]
             print(f"Running command: npx {' '.join(cmd_args)}")
             
             # Execute the command using nodejs-wheel npx

--- a/scripts/services/svc_md_to_mermaid.py
+++ b/scripts/services/svc_md_to_mermaid.py
@@ -5,6 +5,7 @@ MdToMermaid service
 
 import re
 import sys
+import threading
 import zipfile
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -13,6 +14,35 @@ from tempfile import NamedTemporaryFile
 from nodejs_wheel import npx
 
 from scripts.utils.markdown_utils import get_md_text
+
+
+# Function to pre-install mermaid-cli
+def pre_install_mermaid():
+    """
+    Pre-install mermaid-cli using npx to avoid installation during first conversion
+    """
+    try:
+        # Execute npx command to install mermaid-cli
+        cmd_args = ["--yes", "-p", "@mermaid-js/mermaid-cli", "-h"]
+        print("Pre-installing mermaid-cli...")
+        result = npx(cmd_args, return_completed_process=True)
+        print("Mermaid-cli pre-installation completed successfully")
+    except Exception as e:
+        print(f"Warning: Mermaid-cli pre-installation failed: {e}", file=sys.stderr)
+        # Continue execution even if pre-installation fails
+
+
+# Run pre-installation asynchronously when module is imported
+def start_pre_installation():
+    """
+    Start pre-installation in a separate thread to avoid blocking module loading
+    """
+    thread = threading.Thread(target=pre_install_mermaid, daemon=True)
+    thread.start()
+
+
+# Start asynchronous pre-installation
+start_pre_installation()
 
 
 def extract_mermaid_blocks(md_text: str) -> list[str]:

--- a/test/bin/test_md_to_mermaid.sh
+++ b/test/bin/test_md_to_mermaid.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Test script for md_to_mermaid.sh
+
+# Source common functions
+. "$(dirname "${BASH_SOURCE[0]}")/test_common.sh"
+
+# Set up test environment
+setup_test_env
+
+# Run test with test_mermaid.md which contains mermaid code blocks
+run_dir_test "md_to_mermaid" "test_mermaid.md"

--- a/tools/md_to_mermaid/md_to_mermaid.py
+++ b/tools/md_to_mermaid/md_to_mermaid.py
@@ -1,0 +1,70 @@
+from collections.abc import Generator
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from scripts.services.svc_md_to_mermaid import convert_md_to_mermaid
+from scripts.utils.file_utils import get_meta_data
+from scripts.utils.logger_utils import get_logger
+from scripts.utils.mimetype_utils import MimeType
+from scripts.utils.param_utils import get_md_text_from_tool_params, get_param_value
+
+
+class MarkdownToMermaidTool(Tool):
+    logger = get_logger(__name__)
+
+    def _invoke(self, tool_parameters: dict) -> Generator[ToolInvokeMessage, None, None]:
+        """
+        invoke tools
+        """
+
+        # get parameters
+        md_text = get_md_text_from_tool_params(tool_parameters)
+        is_compress = get_param_value(tool_parameters, "is_compress", "true")
+        compress = "true" == is_compress.lower()
+
+        try:
+            # create a temporary output file
+            suffix = ".zip" if compress else ".png"
+            with NamedTemporaryFile(suffix=suffix, delete=False) as temp_output_file:
+                temp_output_path = Path(temp_output_file.name)
+
+            # convert markdown to mermaid PNGs using the shared function
+            created_files = convert_md_to_mermaid(md_text, temp_output_path, compress=compress, is_strip_wrapper=True)
+
+            # generate blob messages based on the created files
+            if compress:
+                # single ZIP file
+                yield self.create_blob_message(
+                    blob=created_files[0].read_bytes(),
+                    meta=get_meta_data(
+                        mime_type=MimeType.ZIP,
+                        output_filename=tool_parameters.get("output_filename"),
+                    ),
+                )
+            else:
+                # multiple PNG files
+                for file_path in created_files:
+                    # determine MIME type based on file suffix
+                    mime_type = MimeType.PNG
+
+                    yield self.create_blob_message(
+                        blob=file_path.read_bytes(),
+                        meta={"mime_type": mime_type}
+                    )
+
+        except Exception as e:
+            self.logger.exception("Failed to convert markdown to mermaid PNG images")
+            yield self.create_text_message(f"Failed to convert markdown to mermaid PNG images, error: {str(e)}")
+            return
+        finally:
+            # clean up temporary files
+            if 'temp_output_path' in locals():
+                temp_output_path.unlink(missing_ok=True)
+            if 'created_files' in locals():
+                for file_path in created_files:
+                    file_path.unlink(missing_ok=True)
+
+        return

--- a/tools/md_to_mermaid/md_to_mermaid.yaml
+++ b/tools/md_to_mermaid/md_to_mermaid.yaml
@@ -1,0 +1,46 @@
+identity:
+  name: md_to_mermaid
+  author: bowenliang123
+  label:
+    en_US: Mermaid diagrams to SVG
+    zh_Hans: 提取 Mermaid 为 SVG 文件
+description:
+  human:
+    en_US: Extract mermaid code blocks in Markdown text to SVG image files
+    zh_Hans: 提取Markdown中Mermaid代码块为SVG图片文件
+  llm: Extract mermaid code blocks in Markdown text to SVG image files
+parameters:
+  - name: md_text
+    type: string
+    required: true
+    label:
+      en_US: Markdown text
+      zh_Hans: Markdown格式文本
+    human_description:
+      en_US: Markdown text
+      zh_Hans: Markdown格式文本
+    form: llm
+  - name: is_compress
+    type: select
+    required: false
+    default: "false"
+    options:
+      - value: "true"
+        label:
+          en_US: "Yes"
+          zh_Hans: 是
+      - value: "false"
+        label:
+          en_US: "No"
+          zh_Hans: 否
+    label:
+      en_US: Generate into ZIP file
+      zh_Hans: 是否压缩为ZIP文件
+    human_description:
+      en_US: Whether to generate into ZIP file
+      zh_Hans: 是否压缩为ZIP文件
+    form: llm
+
+extra:
+  python:
+    source: tools/md_to_mermaid/md_to_mermaid.py

--- a/tools/md_to_mermaid/md_to_mermaid.yaml
+++ b/tools/md_to_mermaid/md_to_mermaid.yaml
@@ -2,13 +2,13 @@ identity:
   name: md_to_mermaid
   author: bowenliang123
   label:
-    en_US: Mermaid diagrams to SVG
-    zh_Hans: 提取 Mermaid 为 SVG 文件
+    en_US: Mermaid markdown diagrams to PNG
+    zh_Hans: 提取 Mermaid Markdown流程图为 PNG 文件
 description:
   human:
-    en_US: Extract mermaid code blocks in Markdown text to SVG image files
-    zh_Hans: 提取Markdown中Mermaid代码块为SVG图片文件
-  llm: Extract mermaid code blocks in Markdown text to SVG image files
+    en_US: Extract Mermaid diagram codeblocks in Markdown text to PNG image files
+    zh_Hans: 提取 Markdown 中 Mermaid 流程图代码块为 PNG 图片文件
+  llm: Extract mermaid code blocks in Markdown text to PNG image files
 parameters:
   - name: md_text
     type: string

--- a/uv.lock
+++ b/uv.lock
@@ -759,11 +759,12 @@ wheels = [
 
 [[package]]
 name = "md-exporter"
-version = "3.0.0"
+version = "3.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "dify-plugin" },
     { name = "markdown" },
+    { name = "nodejs-wheel-binaries" },
     { name = "pandas", extra = ["excel", "html", "xml"] },
     { name = "pillow" },
     { name = "pymupdf" },
@@ -782,6 +783,7 @@ dev = [
 requires-dist = [
     { name = "dify-plugin", specifier = "~=0.7.1" },
     { name = "markdown", specifier = ">=3.10" },
+    { name = "nodejs-wheel-binaries", specifier = ">=20.13.0" },
     { name = "pandas", extras = ["excel", "html", "xml"], specifier = "~=2.3.3" },
     { name = "pillow", specifier = "~=12.0.0" },
     { name = "pymupdf", specifier = "~=1.26.4" },
@@ -911,6 +913,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/8f/0a60e501584145588be1af5cc829265701ba3c35a64aec8e07cbb71d39bb/multidict-6.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:09929cab6fcb68122776d575e03c6cc64ee0b8fca48d17e135474b042ce515cd", size = 53507, upload-time = "2025-10-06T14:51:53.672Z" },
     { url = "https://files.pythonhosted.org/packages/7f/ae/3148b988a9c6239903e786eac19c889fab607c31d6efa7fb2147e5680f23/multidict-6.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:cc41db090ed742f32bd2d2c721861725e6109681eddf835d0a82bd3a5c382827", size = 44804, upload-time = "2025-10-06T14:51:55.415Z" },
     { url = "https://files.pythonhosted.org/packages/b7/da/7d22601b625e241d4f23ef1ebff8acfc60da633c9e7e7922e24d10f592b3/multidict-6.7.0-py3-none-any.whl", hash = "sha256:394fc5c42a333c9ffc3e421a4c85e08580d990e08b99f6bf35b4132114c5dcb3", size = 12317, upload-time = "2025-10-06T14:52:29.272Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/f1/73182280e2c05f49a7c2c8dbd46144efe3f74f03f798fb90da67b4a93bbf/nodejs_wheel_binaries-24.13.0.tar.gz", hash = "sha256:766aed076e900061b83d3e76ad48bfec32a035ef0d41bd09c55e832eb93ef7a4", size = 8056, upload-time = "2026-01-14T11:05:33.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/dc/4d7548aa74a5b446d093f03aff4fb236b570959d793f21c9c42ab6ad870a/nodejs_wheel_binaries-24.13.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:356654baa37bfd894e447e7e00268db403ea1d223863963459a0fbcaaa1d9d48", size = 55133268, upload-time = "2026-01-14T11:05:05.335Z" },
+    { url = "https://files.pythonhosted.org/packages/24/8a/8a4454d28339487240dd2232f42f1090e4a58544c581792d427f6239798c/nodejs_wheel_binaries-24.13.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:92fdef7376120e575f8b397789bafcb13bbd22a1b4d21b060d200b14910f22a5", size = 55314800, upload-time = "2026-01-14T11:05:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/fb/46c600fcc748bd13bc536a735f11532a003b14f5c4dfd6865f5911672175/nodejs_wheel_binaries-24.13.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:3f619ac140e039ecd25f2f71d6e83ad1414017a24608531851b7c31dc140cdfd", size = 59666320, upload-time = "2026-01-14T11:05:12.369Z" },
+    { url = "https://files.pythonhosted.org/packages/85/47/d48f11fc5d1541ace5d806c62a45738a1db9ce33e85a06fe4cd3d9ce83f6/nodejs_wheel_binaries-24.13.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:dfb31ebc2c129538192ddb5bedd3d63d6de5d271437cd39ea26bf3fe229ba430", size = 60162447, upload-time = "2026-01-14T11:05:16.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/74/d285c579ae8157c925b577dde429543963b845e69cd006549e062d1cf5b6/nodejs_wheel_binaries-24.13.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fdd720d7b378d5bb9b2710457bbc880d4c4d1270a94f13fbe257198ac707f358", size = 61659994, upload-time = "2026-01-14T11:05:19.68Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/97/88b4254a2ff93ed2eaed725f77b7d3d2d8d7973bf134359ce786db894faf/nodejs_wheel_binaries-24.13.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ad6383613f3485a75b054647a09f1cd56d12380d7459184eebcf4a5d403f35c", size = 62244373, upload-time = "2026-01-14T11:05:23.987Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c3/0e13a3da78f08cb58650971a6957ac7bfef84164b405176e53ab1e3584e2/nodejs_wheel_binaries-24.13.0-py2.py3-none-win_amd64.whl", hash = "sha256:605be4763e3ef427a3385a55da5a1bcf0a659aa2716eebbf23f332926d7e5f23", size = 41345528, upload-time = "2026-01-14T11:05:27.67Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f1/0578d65b4e3dc572967fd702221ea1f42e1e60accfb6b0dd8d8f15410139/nodejs_wheel_binaries-24.13.0-py2.py3-none-win_arm64.whl", hash = "sha256:2e3431d869d6b2dbeef1d469ad0090babbdcc8baaa72c01dd3cc2c6121c96af5", size = 39054688, upload-time = "2026-01-14T11:05:30.739Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Introduce `md_to_mermaid` tool, convert Mermaid diagram Markdown text into PNG images.
- Use `npx --package` to execute Mermaid cli to conduct the convertion
- Mermaid diagram Markdown text: https://mermaid.js.org/intro/syntax-reference.html
- Mermaid cli : https://github.com/mermaid-js/mermaid-cli