### PR TITLE
[codex] Add standard MCP server and PPTX template validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 # Markdown Exporter
 ### An Agent Skill and Dify plugin to Export Markdown Into Powerful Documents
 
+<!-- mcp-name: io.github.bowenliang123/markdown-exporter -->
+
 
 
 - Author: [bowenliang123](https://github.com/bowenliang123)
@@ -29,6 +31,7 @@
 | Agent Skills                 | **Platforms**: Any platform supporting [Agent Skills](https://agentskills.io) <br/> - **IDEs/CLIs**: [Claude Code](https://code.claude.com/docs/en/skills), [Trae](https://docs.trae.ai/ide/skills), [Codebuddy](https://copilot.tencent.com/docs/cli/skills), etc. <br/> - **Agent Frameworks**: [LangChain DeepAgents](https://www.blog.langchain.com/using-skills-with-deep-agents/), [AgentScope](https://doc.agentscope.io/tutorial/task_agent_skill.html), etc. <br/><br/> **Installation**: <br/> - **Local Import**: Download and import [source code zip](https://github.com/bowenliang123/markdown-exporter/archive/refs/heads/main.zip) <br/> - **Remote Install**: `/plugin marketplace add bowenliang123/markdown-exporter` in agent CLIs |
 | OpenClaw Skills 🦞           | **Platform**: [OpenClaw](https://docs.openclaw.ai/tools/skills#clawhub-install-%2B-sync) <br/> - Install from [ClawHub](https://clawhub.ai/bowenliang123/markdown-exporter): `npx clawhub@latest install markdown-exporter`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | Command Line Interface (CLI) | **Platform**: Python<br/> - Install from [PyPI](https://pypi.org/project/md-exporter/): `pip install md-exporter`<br/> - Run: `markdown-exporter -h` for usage information                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| MCP Server (Prototype)       | **Platforms**: Codex, Claude Desktop, Cursor, VS Code, and other MCP clients <br/> **Installation**: <br/> - Local project: point your MCP client at the `markdown-exporter-mcp` executable in the project virtual environment <br/> - Published package: use a portable launcher command after publishing a dedicated MCP package |
 
 ---
 
@@ -596,6 +599,71 @@ markdown-exporter md_to_ipynb <input> <output> [options]
 ---
 
 ## 📢 Releases
+## MCP Server Usage
+
+`markdown-exporter` now includes a prototype MCP server entry point named `markdown-exporter-mcp`.
+
+### Available MCP Tools
+
+- `export_docx`
+- `export_pdf`
+- `export_pptx`
+- `export_xlsx`
+- `export_html`
+- `export_json`
+
+These tools accept Markdown text directly, generate output files in a managed artifact directory, and return structured metadata for the created artifacts.
+
+### Local Setup
+
+```bash
+uv sync
+```
+
+The MCP server uses stdio transport and is meant to be launched by an MCP client:
+
+```bash
+uv run markdown-exporter-mcp
+```
+
+For a portable launcher after publishing to PyPI, prefer:
+
+```bash
+uvx --from md-exporter markdown-exporter-mcp
+```
+
+### Codex Configuration
+
+Add the following to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.markdown_exporter]
+command = "uvx"
+args = ["--from", "md-exporter", "markdown-exporter-mcp"]
+```
+
+### Generic MCP Client Configuration
+
+```json
+{
+  "mcpServers": {
+    "markdown-exporter": {
+      "command": "uvx",
+      "args": ["--from", "md-exporter", "markdown-exporter-mcp"]
+    }
+  }
+}
+```
+
+### Notes
+
+- The current MCP implementation is a prototype focused on core document export flows.
+- Generated files are written to a managed artifact directory and returned as structured outputs.
+- `md_to_png`, `md_to_ipynb`, `md_to_xml`, `md_to_latex`, and `md_to_codeblock` are not exposed as MCP tools yet.
+- The repository includes [`server.json`](/D:/AIGC/changetomcp/markdown-exporter/server.json) as MCP Registry metadata scaffolding for a future official registry submission.
+
+---
+
 Releases are available at:
 - [GitHub Repo Releases](https://github.com/bowenliang123/markdown-exporter/releases)
 - [Dify Marketplace Releases](https://marketplace.dify.ai/plugins/bowenliang123/md_exporter)

--- a/docs/superpowers/plans/2026-04-03-markdown-exporter-mcp-prototype.md
+++ b/docs/superpowers/plans/2026-04-03-markdown-exporter-mcp-prototype.md
@@ -1,0 +1,162 @@
+# Markdown Exporter MCP Prototype Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a minimal Python MCP server prototype for `markdown-exporter` that exposes one working `export_docx` tool.
+
+**Architecture:** Keep `md_exporter` as the core conversion library and add a new `markdown_exporter_mcp` package for MCP protocol glue. The first slice adds a focused facade, artifact management, a single DOCX export tool, and a test that exercises the tool handler directly without a full client round-trip.
+
+**Tech Stack:** Python 3.11, `mcp`, `pydantic`, `pytest`, existing `md_exporter` services
+
+---
+
+### Task 1: Add the first failing MCP test
+
+**Files:**
+- Create: `test/mcp/test_export_docx.py`
+- Test: `test/resources/example_md.md`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from pathlib import Path
+
+from markdown_exporter_mcp.tools.export_docx import handle_export_docx
+
+
+def test_export_docx_creates_artifact(tmp_path: Path) -> None:
+    markdown = Path("test/resources/example_md.md").read_text(encoding="utf-8")
+
+    result = handle_export_docx(
+        markdown=markdown,
+        file_name="report.docx",
+        options={"strip_wrapper": False, "toc": False, "template_path": None},
+        artifact_root=tmp_path,
+    )
+
+    assert result.success is True
+    assert result.artifacts[0].name == "report.docx"
+    assert result.artifacts[0].path.endswith("report.docx")
+    assert Path(result.artifacts[0].path).exists()
+    assert Path(result.artifacts[0].path).stat().st_size > 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest test/mcp/test_export_docx.py -v`
+Expected: FAIL with `ModuleNotFoundError` because `markdown_exporter_mcp` does not exist yet.
+
+### Task 2: Add the minimal shared interfaces
+
+**Files:**
+- Create: `md_exporter/facade.py`
+- Create: `markdown_exporter_mcp/schemas.py`
+- Create: `markdown_exporter_mcp/runtime/artifacts.py`
+
+- [ ] **Step 1: Add a facade for DOCX export**
+
+```python
+from pathlib import Path
+
+from .services.svc_md_to_docx import convert_md_to_docx
+
+
+def export_docx(
+    markdown: str,
+    output_path: Path,
+    *,
+    template_path: Path | None = None,
+    strip_wrapper: bool = False,
+    toc: bool = False,
+) -> None:
+    convert_md_to_docx(markdown, output_path, template_path, strip_wrapper, toc)
+```
+
+- [ ] **Step 2: Add MCP result models**
+
+```python
+from pydantic import BaseModel
+
+
+class Artifact(BaseModel):
+    path: str
+    name: str
+    mime_type: str
+    size: int
+
+
+class ExportResult(BaseModel):
+    success: bool
+    summary: str
+    artifacts: list[Artifact]
+```
+
+- [ ] **Step 3: Add artifact helpers**
+
+```python
+def create_job_dir(root: Path | None = None) -> Path: ...
+def sanitize_file_name(file_name: str | None, default_name: str) -> str: ...
+def build_artifact(path: Path, mime_type: str) -> Artifact: ...
+```
+
+### Task 3: Implement the minimal MCP package
+
+**Files:**
+- Create: `markdown_exporter_mcp/__init__.py`
+- Create: `markdown_exporter_mcp/__main__.py`
+- Create: `markdown_exporter_mcp/server.py`
+- Create: `markdown_exporter_mcp/tools/export_docx.py`
+
+- [ ] **Step 1: Implement the pure DOCX tool handler**
+
+```python
+def handle_export_docx(..., artifact_root: Path | None = None) -> ExportResult:
+    ...
+```
+
+- [ ] **Step 2: Register the tool on a FastMCP server**
+
+```python
+def register_export_docx(server: FastMCP) -> None:
+    @server.tool()
+    def export_docx(...):
+        return handle_export_docx(...)
+```
+
+- [ ] **Step 3: Add `create_server()` and `main()`**
+
+```python
+def create_server() -> FastMCP:
+    server = FastMCP("markdown-exporter")
+    register_export_docx(server)
+    return server
+```
+
+### Task 4: Wire packaging and verify green
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add MCP dependencies and script entry point**
+
+```toml
+dependencies = [
+    "...",
+    "mcp>=1.0.0",
+    "pydantic>=2.0.0",
+]
+
+[project.scripts]
+markdown-exporter = "md_exporter.cli:main"
+markdown-exporter-mcp = "markdown_exporter_mcp.server:main"
+```
+
+- [ ] **Step 2: Run the focused test**
+
+Run: `uv run pytest test/mcp/test_export_docx.py -v`
+Expected: PASS
+
+- [ ] **Step 3: Run the existing DOCX CLI regression test**
+
+Run: `uv run pytest test/skills/test_md_to_docx.py -v`
+Expected: PASS

--- a/markdown_exporter_mcp/__init__.py
+++ b/markdown_exporter_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP server package for markdown-exporter."""

--- a/markdown_exporter_mcp/__main__.py
+++ b/markdown_exporter_mcp/__main__.py
@@ -1,0 +1,5 @@
+from .server import main
+
+
+if __name__ == "__main__":
+    main()

--- a/markdown_exporter_mcp/runtime/__init__.py
+++ b/markdown_exporter_mcp/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime helpers for the markdown-exporter MCP package."""

--- a/markdown_exporter_mcp/runtime/artifacts.py
+++ b/markdown_exporter_mcp/runtime/artifacts.py
@@ -1,0 +1,45 @@
+import os
+from pathlib import Path
+from uuid import uuid4
+
+from markdown_exporter_mcp.schemas import Artifact
+
+
+def get_artifact_root(root: Path | None = None) -> Path:
+    """Return the base directory used to store MCP-generated artifacts."""
+    if root is not None:
+        artifact_root = Path(root)
+    else:
+        local_app_data = os.getenv("LOCALAPPDATA")
+        if local_app_data:
+            artifact_root = Path(local_app_data) / "markdown-exporter-mcp" / "artifacts"
+        else:
+            artifact_root = Path.home() / ".cache" / "markdown-exporter-mcp" / "artifacts"
+
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    return artifact_root
+
+
+def create_job_dir(root: Path | None = None) -> Path:
+    """Create an isolated output directory for one MCP tool invocation."""
+    job_dir = get_artifact_root(root) / uuid4().hex
+    job_dir.mkdir(parents=True, exist_ok=True)
+    return job_dir
+
+
+def sanitize_file_name(file_name: str | None, default_name: str) -> str:
+    """Normalize a user-provided file name to a safe leaf name."""
+    candidate = (file_name or default_name).strip()
+    if not candidate:
+        candidate = default_name
+    return Path(candidate).name
+
+
+def build_artifact(path: Path, mime_type: str) -> Artifact:
+    """Build artifact metadata for a generated output file."""
+    return Artifact(
+        path=str(path.resolve()),
+        name=path.name,
+        mime_type=mime_type,
+        size=path.stat().st_size,
+    )

--- a/markdown_exporter_mcp/schemas.py
+++ b/markdown_exporter_mcp/schemas.py
@@ -1,0 +1,43 @@
+from pydantic import BaseModel, Field
+
+
+class Artifact(BaseModel):
+    path: str
+    name: str
+    mime_type: str
+    size: int = Field(ge=0)
+
+
+class ExportResult(BaseModel):
+    success: bool
+    summary: str
+    artifacts: list[Artifact]
+
+
+class DocxOptions(BaseModel):
+    strip_wrapper: bool = False
+    toc: bool = False
+    template_path: str | None = None
+
+
+class PdfOptions(BaseModel):
+    strip_wrapper: bool = False
+
+
+class PptxOptions(BaseModel):
+    strip_wrapper: bool = False
+    template_path: str | None = None
+
+
+class XlsxOptions(BaseModel):
+    strip_wrapper: bool = False
+    force_text: bool = True
+
+
+class HtmlOptions(BaseModel):
+    strip_wrapper: bool = False
+
+
+class JsonOptions(BaseModel):
+    strip_wrapper: bool = False
+    style: str = "jsonl"

--- a/markdown_exporter_mcp/server.py
+++ b/markdown_exporter_mcp/server.py
@@ -1,0 +1,53 @@
+import argparse
+from importlib.metadata import PackageNotFoundError, version
+
+from mcp.server.fastmcp import FastMCP
+
+from markdown_exporter_mcp.tools.export_docx import register_export_docx
+from markdown_exporter_mcp.tools.export_html import register_export_html
+from markdown_exporter_mcp.tools.export_json import register_export_json
+from markdown_exporter_mcp.tools.export_pdf import register_export_pdf
+from markdown_exporter_mcp.tools.export_pptx import register_export_pptx
+from markdown_exporter_mcp.tools.export_xlsx import register_export_xlsx
+
+
+def get_server_version() -> str:
+    """Return the published package version used for MCP server metadata."""
+    try:
+        return version("md-exporter")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+def create_server(host: str = "127.0.0.1", port: int = 8000) -> FastMCP:
+    """Create the markdown-exporter MCP server with the currently supported tools."""
+    server = FastMCP("markdown-exporter", host=host, port=port)
+    server._mcp_server.version = get_server_version()
+    register_export_docx(server)
+    register_export_pdf(server)
+    register_export_pptx(server)
+    register_export_xlsx(server)
+    register_export_html(server)
+    register_export_json(server)
+    return server
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for local stdio or remote streamable HTTP startup."""
+    parser = argparse.ArgumentParser(description="Run the markdown-exporter MCP server.")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "streamable-http"],
+        default="stdio",
+        help="Transport to use. stdio is best for local spawned clients; streamable-http is best for remote hosting.",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Host to bind when using streamable-http transport.")
+    parser.add_argument("--port", type=int, default=8000, help="Port to bind when using streamable-http transport.")
+    parser.add_argument("--mount-path", default=None, help="Optional HTTP mount path, for example /mcp.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the markdown-exporter MCP server using the selected transport."""
+    args = parse_args(argv)
+    create_server(host=args.host, port=args.port).run(transport=args.transport, mount_path=args.mount_path)

--- a/markdown_exporter_mcp/tools/__init__.py
+++ b/markdown_exporter_mcp/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tool registration helpers for markdown-exporter MCP."""

--- a/markdown_exporter_mcp/tools/export_docx.py
+++ b/markdown_exporter_mcp/tools/export_docx.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_exporter.facade import export_docx as export_docx_file
+from markdown_exporter_mcp.runtime.artifacts import build_artifact, create_job_dir, sanitize_file_name
+from markdown_exporter_mcp.schemas import DocxOptions, ExportResult
+
+DOCX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+
+def handle_export_docx(
+    *,
+    markdown: str,
+    file_name: str | None = None,
+    options: DocxOptions | dict | None = None,
+    artifact_root: Path | None = None,
+) -> ExportResult:
+    """Export Markdown text into a DOCX artifact and return structured metadata."""
+    if not markdown.strip():
+        raise ValueError("markdown must not be empty")
+
+    docx_options = options if isinstance(options, DocxOptions) else DocxOptions.model_validate(options or {})
+    final_file_name = sanitize_file_name(file_name, "document.docx")
+    if not final_file_name.lower().endswith(".docx"):
+        final_file_name = f"{final_file_name}.docx"
+
+    output_dir = create_job_dir(artifact_root)
+    output_path = output_dir / final_file_name
+    template_path = Path(docx_options.template_path) if docx_options.template_path else None
+
+    export_docx_file(
+        markdown,
+        output_path,
+        template_path=template_path,
+        strip_wrapper=docx_options.strip_wrapper,
+        toc=docx_options.toc,
+    )
+
+    artifact = build_artifact(output_path, DOCX_MIME_TYPE)
+    return ExportResult(
+        success=True,
+        summary=f"Exported Markdown to DOCX: {artifact.name}",
+        artifacts=[artifact],
+    )
+
+
+def register_export_docx(server: FastMCP) -> None:
+    """Register the DOCX export tool on the provided MCP server."""
+
+    @server.tool(name="export_docx", description="Export Markdown content to a DOCX document.", structured_output=True)
+    def export_docx(markdown: str, file_name: str | None = None, options: dict | None = None) -> ExportResult:
+        return handle_export_docx(markdown=markdown, file_name=file_name, options=options)

--- a/markdown_exporter_mcp/tools/export_html.py
+++ b/markdown_exporter_mcp/tools/export_html.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_exporter.facade import export_html as export_html_file
+from markdown_exporter_mcp.runtime.artifacts import build_artifact, create_job_dir, sanitize_file_name
+from markdown_exporter_mcp.schemas import ExportResult, HtmlOptions
+
+HTML_MIME_TYPE = "text/html"
+
+
+def handle_export_html(
+    *,
+    markdown: str,
+    file_name: str | None = None,
+    options: HtmlOptions | dict | None = None,
+    artifact_root: Path | None = None,
+) -> ExportResult:
+    if not markdown.strip():
+        raise ValueError("markdown must not be empty")
+
+    html_options = options if isinstance(options, HtmlOptions) else HtmlOptions.model_validate(options or {})
+    final_file_name = sanitize_file_name(file_name, "document.html")
+    if not final_file_name.lower().endswith(".html"):
+        final_file_name = f"{final_file_name}.html"
+
+    output_dir = create_job_dir(artifact_root)
+    output_path = output_dir / final_file_name
+
+    export_html_file(markdown, output_path, strip_wrapper=html_options.strip_wrapper)
+
+    artifact = build_artifact(output_path, HTML_MIME_TYPE)
+    return ExportResult(
+        success=True,
+        summary=f"Exported Markdown to HTML: {artifact.name}",
+        artifacts=[artifact],
+    )
+
+
+def register_export_html(server: FastMCP) -> None:
+    @server.tool(name="export_html", description="Export Markdown content to an HTML document.", structured_output=True)
+    def export_html(markdown: str, file_name: str | None = None, options: dict | None = None) -> ExportResult:
+        return handle_export_html(markdown=markdown, file_name=file_name, options=options)

--- a/markdown_exporter_mcp/tools/export_json.py
+++ b/markdown_exporter_mcp/tools/export_json.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_exporter.facade import export_json as export_json_files
+from markdown_exporter_mcp.runtime.artifacts import build_artifact, create_job_dir, sanitize_file_name
+from markdown_exporter_mcp.schemas import ExportResult, JsonOptions
+
+JSON_MIME_TYPE = "application/json"
+
+
+def handle_export_json(
+    *,
+    markdown: str,
+    file_name: str | None = None,
+    options: JsonOptions | dict | None = None,
+    artifact_root: Path | None = None,
+) -> ExportResult:
+    if not markdown.strip():
+        raise ValueError("markdown must not be empty")
+
+    json_options = options if isinstance(options, JsonOptions) else JsonOptions.model_validate(options or {})
+    final_file_name = sanitize_file_name(file_name, "table.json")
+    if not final_file_name.lower().endswith(".json"):
+        final_file_name = f"{final_file_name}.json"
+
+    output_dir = create_job_dir(artifact_root)
+    output_path = output_dir / final_file_name
+
+    created_paths = export_json_files(
+        markdown,
+        output_path,
+        style=json_options.style,
+        strip_wrapper=json_options.strip_wrapper,
+    )
+
+    artifacts = [build_artifact(path, JSON_MIME_TYPE) for path in created_paths]
+    return ExportResult(
+        success=True,
+        summary=f"Exported Markdown to JSON artifacts: {len(artifacts)} file(s)",
+        artifacts=artifacts,
+    )
+
+
+def register_export_json(server: FastMCP) -> None:
+    @server.tool(name="export_json", description="Export Markdown table content to JSON files.", structured_output=True)
+    def export_json(markdown: str, file_name: str | None = None, options: dict | None = None) -> ExportResult:
+        return handle_export_json(markdown=markdown, file_name=file_name, options=options)

--- a/markdown_exporter_mcp/tools/export_pdf.py
+++ b/markdown_exporter_mcp/tools/export_pdf.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_exporter.facade import export_pdf as export_pdf_file
+from markdown_exporter_mcp.runtime.artifacts import build_artifact, create_job_dir, sanitize_file_name
+from markdown_exporter_mcp.schemas import ExportResult, PdfOptions
+
+PDF_MIME_TYPE = "application/pdf"
+
+
+def handle_export_pdf(
+    *,
+    markdown: str,
+    file_name: str | None = None,
+    options: PdfOptions | dict | None = None,
+    artifact_root: Path | None = None,
+) -> ExportResult:
+    if not markdown.strip():
+        raise ValueError("markdown must not be empty")
+
+    pdf_options = options if isinstance(options, PdfOptions) else PdfOptions.model_validate(options or {})
+    final_file_name = sanitize_file_name(file_name, "document.pdf")
+    if not final_file_name.lower().endswith(".pdf"):
+        final_file_name = f"{final_file_name}.pdf"
+
+    output_dir = create_job_dir(artifact_root)
+    output_path = output_dir / final_file_name
+
+    export_pdf_file(markdown, output_path, strip_wrapper=pdf_options.strip_wrapper)
+
+    artifact = build_artifact(output_path, PDF_MIME_TYPE)
+    return ExportResult(
+        success=True,
+        summary=f"Exported Markdown to PDF: {artifact.name}",
+        artifacts=[artifact],
+    )
+
+
+def register_export_pdf(server: FastMCP) -> None:
+    @server.tool(name="export_pdf", description="Export Markdown content to a PDF document.", structured_output=True)
+    def export_pdf(markdown: str, file_name: str | None = None, options: dict | None = None) -> ExportResult:
+        return handle_export_pdf(markdown=markdown, file_name=file_name, options=options)

--- a/markdown_exporter_mcp/tools/export_pptx.py
+++ b/markdown_exporter_mcp/tools/export_pptx.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+from zipfile import BadZipFile, ZipFile
+
+from mcp.server.fastmcp import FastMCP
+
+from md_exporter.facade import export_pptx as export_pptx_file
+from markdown_exporter_mcp.runtime.artifacts import build_artifact, create_job_dir, sanitize_file_name
+from markdown_exporter_mcp.schemas import ExportResult, PptxOptions
+
+PPTX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+
+REQUIRED_PPTX_ENTRIES = {
+    "[Content_Types].xml",
+    "ppt/presentation.xml",
+    "ppt/_rels/presentation.xml.rels",
+}
+
+
+def validate_pptx_template(template_path: Path) -> None:
+    """Validate that a custom template looks like a readable PowerPoint .pptx package."""
+    if not template_path.exists():
+        raise ValueError(f"Invalid PPTX template: file not found: {template_path}")
+    if template_path.suffix.lower() != ".pptx":
+        raise ValueError(f"Invalid PPTX template: expected a .pptx file, got: {template_path.name}")
+
+    try:
+        with ZipFile(template_path) as archive:
+            entry_names = set(archive.namelist())
+    except BadZipFile as exc:
+        raise ValueError(
+            "Invalid PPTX template: the file is not a valid Office .pptx archive. "
+            "Open it in Microsoft PowerPoint and save it again as a normal .pptx file."
+        ) from exc
+
+    missing_entries = sorted(REQUIRED_PPTX_ENTRIES - entry_names)
+    if missing_entries:
+        raise ValueError(
+            "Invalid PPTX template: missing required PowerPoint package parts: " + ", ".join(missing_entries)
+        )
+
+
+def handle_export_pptx(
+    *,
+    markdown: str,
+    file_name: str | None = None,
+    options: PptxOptions | dict | None = None,
+    artifact_root: Path | None = None,
+) -> ExportResult:
+    if not markdown.strip():
+        raise ValueError("markdown must not be empty")
+
+    pptx_options = options if isinstance(options, PptxOptions) else PptxOptions.model_validate(options or {})
+    final_file_name = sanitize_file_name(file_name, "slides.pptx")
+    if not final_file_name.lower().endswith(".pptx"):
+        final_file_name = f"{final_file_name}.pptx"
+
+    output_dir = create_job_dir(artifact_root)
+    output_path = output_dir / final_file_name
+    template_path = Path(pptx_options.template_path) if pptx_options.template_path else None
+    if template_path is not None:
+        validate_pptx_template(template_path)
+
+    export_pptx_file(
+        markdown,
+        output_path,
+        template_path=template_path,
+        strip_wrapper=pptx_options.strip_wrapper,
+    )
+
+    artifact = build_artifact(output_path, PPTX_MIME_TYPE)
+    return ExportResult(
+        success=True,
+        summary=f"Exported Markdown to PPTX: {artifact.name}",
+        artifacts=[artifact],
+    )
+
+
+def register_export_pptx(server: FastMCP) -> None:
+    @server.tool(name="export_pptx", description="Export Markdown content to a PPTX presentation.", structured_output=True)
+    def export_pptx(markdown: str, file_name: str | None = None, options: dict | None = None) -> ExportResult:
+        return handle_export_pptx(markdown=markdown, file_name=file_name, options=options)

--- a/markdown_exporter_mcp/tools/export_xlsx.py
+++ b/markdown_exporter_mcp/tools/export_xlsx.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_exporter.facade import export_xlsx as export_xlsx_file
+from markdown_exporter_mcp.runtime.artifacts import build_artifact, create_job_dir, sanitize_file_name
+from markdown_exporter_mcp.schemas import ExportResult, XlsxOptions
+
+XLSX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+
+def handle_export_xlsx(
+    *,
+    markdown: str,
+    file_name: str | None = None,
+    options: XlsxOptions | dict | None = None,
+    artifact_root: Path | None = None,
+) -> ExportResult:
+    if not markdown.strip():
+        raise ValueError("markdown must not be empty")
+
+    xlsx_options = options if isinstance(options, XlsxOptions) else XlsxOptions.model_validate(options or {})
+    final_file_name = sanitize_file_name(file_name, "table.xlsx")
+    if not final_file_name.lower().endswith(".xlsx"):
+        final_file_name = f"{final_file_name}.xlsx"
+
+    output_dir = create_job_dir(artifact_root)
+    output_path = output_dir / final_file_name
+
+    export_xlsx_file(
+        markdown,
+        output_path,
+        strip_wrapper=xlsx_options.strip_wrapper,
+        force_text=xlsx_options.force_text,
+    )
+
+    artifact = build_artifact(output_path, XLSX_MIME_TYPE)
+    return ExportResult(
+        success=True,
+        summary=f"Exported Markdown to XLSX: {artifact.name}",
+        artifacts=[artifact],
+    )
+
+
+def register_export_xlsx(server: FastMCP) -> None:
+    @server.tool(name="export_xlsx", description="Export Markdown table content to an XLSX workbook.", structured_output=True)
+    def export_xlsx(markdown: str, file_name: str | None = None, options: dict | None = None) -> ExportResult:
+        return handle_export_xlsx(markdown=markdown, file_name=file_name, options=options)

--- a/md_exporter/facade.py
+++ b/md_exporter/facade.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+from .services.svc_md_to_docx import convert_md_to_docx
+from .services.svc_md_to_html import convert_md_to_html
+from .services.svc_md_to_json import convert_md_to_json
+from .services.svc_md_to_pdf import convert_md_to_pdf
+from .services.svc_md_to_pptx import convert_md_to_pptx
+from .services.svc_md_to_xlsx import convert_md_to_xlsx
+
+
+def export_docx(
+    markdown: str,
+    output_path: Path,
+    *,
+    template_path: Path | None = None,
+    strip_wrapper: bool = False,
+    toc: bool = False,
+) -> None:
+    """Export Markdown content to a DOCX file using the shared service layer."""
+    convert_md_to_docx(markdown, output_path, template_path, strip_wrapper, toc)
+
+
+def export_pdf(markdown: str, output_path: Path, *, strip_wrapper: bool = False) -> None:
+    """Export Markdown content to a PDF file using the shared service layer."""
+    convert_md_to_pdf(markdown, output_path, strip_wrapper)
+
+
+def export_pptx(
+    markdown: str,
+    output_path: Path,
+    *,
+    template_path: Path | None = None,
+    strip_wrapper: bool = False,
+) -> Path:
+    """Export Markdown content to a PPTX file using the shared service layer."""
+    return convert_md_to_pptx(markdown, output_path, template_path, strip_wrapper)
+
+
+def export_xlsx(markdown: str, output_path: Path, *, strip_wrapper: bool = False, force_text: bool = True) -> None:
+    """Export Markdown table content to an XLSX file using the shared service layer."""
+    convert_md_to_xlsx(markdown, output_path, strip_wrapper, force_text)
+
+
+def export_html(markdown: str, output_path: Path, *, strip_wrapper: bool = False) -> None:
+    """Export Markdown content to an HTML file using the shared service layer."""
+    convert_md_to_html(markdown, output_path, strip_wrapper)
+
+
+def export_json(
+    markdown: str,
+    output_path: Path,
+    *,
+    style: str = "jsonl",
+    strip_wrapper: bool = False,
+) -> list[Path]:
+    """Export Markdown table content to JSON files using the shared service layer."""
+    return convert_md_to_json(markdown, output_path, style, strip_wrapper)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "PyMuPDF~=1.27.1",
     "pillow~=12.1.1",
     "pypandoc-binary~=1.16.2",
+    "mcp>=1.27.0",
+    "pydantic>=2.12.5",
 ]
 
 [dependency-groups]
@@ -35,11 +37,11 @@ Issues = "https://github.com/bowenliang123/markdown-exporter/issues"
 Changelog = "https://github.com/bowenliang123/markdown-exporter/?tab=readme-ov-file#-changelog"
 
 [build-system]
-requires = ["uv_build>=0.10.4,<0.11.0"]
+requires = ["uv_build>=0.11.3,<0.12.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = "md_exporter"
+module-name = ["md_exporter", "markdown_exporter_mcp"]
 module-root = ""
 
 [tool.uv.build-backend.includes]
@@ -47,3 +49,4 @@ assets = "md_exporter/assets/"
 
 [project.scripts]
 markdown-exporter = "md_exporter.cli:main"
+markdown-exporter-mcp = "markdown_exporter_mcp.server:main"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.bowenliang123/markdown-exporter",
+  "title": "Markdown Exporter",
+  "description": "Convert Markdown into DOCX, PDF, PPTX, XLSX, HTML, and JSON through a standard MCP server.",
+  "repository": {
+    "url": "https://github.com/bowenliang123/markdown-exporter",
+    "source": "github"
+  },
+  "version": "3.6.9",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "md-exporter",
+      "version": "3.6.9",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/test/mcp/test_export_docx.py
+++ b/test/mcp/test_export_docx.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from markdown_exporter_mcp.tools.export_docx import handle_export_docx
+
+
+def test_export_docx_creates_artifact(tmp_path: Path) -> None:
+    markdown = Path("test/resources/example_md.md").read_text(encoding="utf-8")
+
+    result = handle_export_docx(
+        markdown=markdown,
+        file_name="report.docx",
+        options={"strip_wrapper": False, "toc": False, "template_path": None},
+        artifact_root=tmp_path,
+    )
+
+    assert result.success is True
+    assert result.summary
+    assert len(result.artifacts) == 1
+
+    artifact = result.artifacts[0]
+    artifact_path = Path(artifact.path)
+
+    assert artifact.name == "report.docx"
+    assert artifact.mime_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    assert artifact_path.exists()
+    assert artifact_path.stat().st_size > 0

--- a/test/mcp/test_export_formats.py
+++ b/test/mcp/test_export_formats.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+
+from markdown_exporter_mcp.tools.export_html import handle_export_html
+from markdown_exporter_mcp.tools.export_json import handle_export_json
+from markdown_exporter_mcp.tools.export_pdf import handle_export_pdf
+from markdown_exporter_mcp.tools.export_pptx import handle_export_pptx
+from markdown_exporter_mcp.tools.export_xlsx import handle_export_xlsx
+
+
+def test_export_pdf_creates_artifact(tmp_path: Path) -> None:
+    markdown = Path("test/resources/example_md.md").read_text(encoding="utf-8")
+
+    result = handle_export_pdf(
+        markdown=markdown,
+        file_name="report.pdf",
+        options={"strip_wrapper": False},
+        artifact_root=tmp_path,
+    )
+
+    artifact = result.artifacts[0]
+    artifact_path = Path(artifact.path)
+
+    assert result.success is True
+    assert artifact.name == "report.pdf"
+    assert artifact.mime_type == "application/pdf"
+    assert artifact_path.exists()
+    assert artifact_path.stat().st_size > 0
+
+
+def test_export_pptx_creates_artifact(tmp_path: Path) -> None:
+    markdown = Path("test/resources/example_md_pptx.md").read_text(encoding="utf-8")
+
+    result = handle_export_pptx(
+        markdown=markdown,
+        file_name="slides.pptx",
+        options={"strip_wrapper": False, "template_path": None},
+        artifact_root=tmp_path,
+    )
+
+    artifact = result.artifacts[0]
+    artifact_path = Path(artifact.path)
+
+    assert result.success is True
+    assert artifact.name == "slides.pptx"
+    assert artifact.mime_type == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    assert artifact_path.exists()
+    assert artifact_path.stat().st_size > 0
+
+
+def test_export_pptx_rejects_invalid_template(tmp_path: Path) -> None:
+    markdown = Path("test/resources/example_md_pptx.md").read_text(encoding="utf-8")
+    bad_template = tmp_path / "broken-template.pptx"
+    bad_template.write_text("not a real pptx", encoding="utf-8")
+
+    try:
+        handle_export_pptx(
+            markdown=markdown,
+            file_name="slides.pptx",
+            options={"strip_wrapper": False, "template_path": str(bad_template)},
+            artifact_root=tmp_path,
+        )
+    except ValueError as exc:
+        assert "Invalid PPTX template" in str(exc)
+    else:
+        raise AssertionError("Expected invalid PPTX template to be rejected")
+
+
+def test_export_pptx_rejects_non_pptx_extension(tmp_path: Path) -> None:
+    markdown = Path("test/resources/example_md_pptx.md").read_text(encoding="utf-8")
+    wrong_extension = tmp_path / "template.zip"
+    wrong_extension.write_text("not a pptx", encoding="utf-8")
+
+    try:
+        handle_export_pptx(
+            markdown=markdown,
+            file_name="slides.pptx",
+            options={"strip_wrapper": False, "template_path": str(wrong_extension)},
+            artifact_root=tmp_path,
+        )
+    except ValueError as exc:
+        assert "expected a .pptx file" in str(exc)
+    else:
+        raise AssertionError("Expected non-.pptx template to be rejected")
+
+
+def test_export_pptx_rejects_missing_pptx_parts(tmp_path: Path) -> None:
+    import zipfile
+
+    markdown = Path("test/resources/example_md_pptx.md").read_text(encoding="utf-8")
+    incomplete_template = tmp_path / "incomplete.pptx"
+    with zipfile.ZipFile(incomplete_template, "w") as archive:
+        archive.writestr("[Content_Types].xml", "<Types />")
+
+    try:
+        handle_export_pptx(
+            markdown=markdown,
+            file_name="slides.pptx",
+            options={"strip_wrapper": False, "template_path": str(incomplete_template)},
+            artifact_root=tmp_path,
+        )
+    except ValueError as exc:
+        assert "missing required PowerPoint package parts" in str(exc)
+    else:
+        raise AssertionError("Expected incomplete PPTX template to be rejected")
+
+
+def test_export_xlsx_creates_artifact(tmp_path: Path) -> None:
+    markdown = Path("test/resources/example_md_table.md").read_text(encoding="utf-8")
+
+    result = handle_export_xlsx(
+        markdown=markdown,
+        file_name="table.xlsx",
+        options={"strip_wrapper": False, "force_text": True},
+        artifact_root=tmp_path,
+    )
+
+    artifact = result.artifacts[0]
+    artifact_path = Path(artifact.path)
+
+    assert result.success is True
+    assert artifact.name == "table.xlsx"
+    assert artifact.mime_type == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    assert artifact_path.exists()
+    assert artifact_path.stat().st_size > 0
+
+
+def test_export_html_creates_artifact(tmp_path: Path) -> None:
+    markdown = Path("test/resources/example_md.md").read_text(encoding="utf-8")
+
+    result = handle_export_html(
+        markdown=markdown,
+        file_name="page.html",
+        options={"strip_wrapper": False},
+        artifact_root=tmp_path,
+    )
+
+    artifact = result.artifacts[0]
+    artifact_path = Path(artifact.path)
+
+    assert result.success is True
+    assert artifact.name == "page.html"
+    assert artifact.mime_type == "text/html"
+    assert artifact_path.exists()
+    assert artifact_path.read_text(encoding="utf-8")
+
+
+def test_export_json_creates_artifact(tmp_path: Path) -> None:
+    markdown = Path("test/resources/example_md_table.md").read_text(encoding="utf-8")
+
+    result = handle_export_json(
+        markdown=markdown,
+        file_name="table.json",
+        options={"strip_wrapper": False, "style": "jsonl"},
+        artifact_root=tmp_path,
+    )
+
+    artifact = result.artifacts[0]
+    artifact_path = Path(artifact.path)
+
+    assert result.success is True
+    assert artifact.name == "table.json"
+    assert artifact.mime_type == "application/json"
+    assert artifact_path.exists()
+    assert artifact_path.read_text(encoding="utf-8")

--- a/test/mcp/test_server_cli.py
+++ b/test/mcp/test_server_cli.py
@@ -1,0 +1,46 @@
+from markdown_exporter_mcp import server as server_module
+
+
+def test_parse_args_defaults_to_stdio() -> None:
+    args = server_module.parse_args([])
+
+    assert args.transport == "stdio"
+    assert args.host == "127.0.0.1"
+    assert args.port == 8000
+    assert args.mount_path is None
+
+
+def test_parse_args_supports_streamable_http() -> None:
+    args = server_module.parse_args(
+        ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8931", "--mount-path", "/mcp"]
+    )
+
+    assert args.transport == "streamable-http"
+    assert args.host == "0.0.0.0"
+    assert args.port == 8931
+    assert args.mount_path == "/mcp"
+
+
+def test_main_runs_server_with_selected_transport(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class DummyServer:
+        def run(self, transport: str = "stdio", mount_path: str | None = None) -> None:
+            captured["transport"] = transport
+            captured["mount_path"] = mount_path
+
+    def fake_create_server(host: str = "127.0.0.1", port: int = 8000):
+        captured["host"] = host
+        captured["port"] = port
+        return DummyServer()
+
+    monkeypatch.setattr(server_module, "create_server", fake_create_server)
+
+    server_module.main(["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9000", "--mount-path", "/mcp"])
+
+    assert captured == {
+        "host": "0.0.0.0",
+        "port": 9000,
+        "transport": "streamable-http",
+        "mount_path": "/mcp",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -540,6 +549,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -576,6 +594,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -764,14 +809,41 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
 name = "md-exporter"
 version = "3.6.9"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
     { name = "markdown" },
+    { name = "mcp" },
     { name = "pandas", extra = ["excel", "html", "xml"] },
     { name = "pillow" },
+    { name = "pydantic" },
     { name = "pymupdf" },
     { name = "pypandoc-binary" },
     { name = "xhtml2pdf" },
@@ -790,8 +862,10 @@ dify = [
 requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "markdown", specifier = ">=3.10.2" },
+    { name = "mcp", specifier = ">=1.27.0" },
     { name = "pandas", extras = ["excel", "html", "xml"], specifier = "~=3.0.1" },
     { name = "pillow", specifier = "~=12.1.1" },
+    { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pymupdf", specifier = "~=1.27.1" },
     { name = "pypandoc-binary", specifier = "~=1.16.2" },
     { name = "xhtml2pdf", specifier = "~=0.2.17" },
@@ -1516,6 +1590,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pymupdf"
 version = "1.27.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1759,6 +1847,34 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "pyxlsb"
 version = "1.0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1820,6 +1936,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -1968,6 +2098,114 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2017,6 +2255,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -2135,6 +2399,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.42.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a standard MCP server package for markdown-exporter with DOCX, PDF, PPTX, XLSX, HTML, and JSON export tools
- add local and streamable-http MCP startup support plus registry metadata scaffolding
- add MCP-only PPTX template preflight validation to reject broken company templates earlier with clearer errors

## Validation
- uv run pytest test/mcp/test_server_cli.py test/mcp/test_export_docx.py test/mcp/test_export_formats.py -q
- uv run pytest test/skills/test_md_to_pptx.py test/skills/test_md_to_docx.py test/skills/test_md_to_pdf.py test/skills/test_md_to_xlsx.py test/skills/test_md_to_html.py test/skills/test_md_to_json.py -q
- uv build
