### PR TITLE
Preserve single Markdown line breaks in exports

### DIFF
--- a/md_exporter/utils/markdown_utils.py
+++ b/md_exporter/utils/markdown_utils.py
@@ -30,7 +30,7 @@ CSS_FOR_TABLE = """
 
 def convert_markdown_to_html(md_text: str) -> str:
     """Convert Markdown to HTML"""
-    html = markdown.markdown(text=md_text, extensions=["extra", "toc"])
+    html = markdown.markdown(text=md_text, extensions=["extra", "toc", "nl2br"])
     return (
         f"""
     {html}

--- a/md_exporter/utils/pandoc_utils.py
+++ b/md_exporter/utils/pandoc_utils.py
@@ -8,7 +8,8 @@ import tempfile
 
 from md_exporter.utils import get_logger
 
-DEFAULT_ENABLED_INPUT_EXTENSIONS = []
+# Preserve line-separated Markdown content as hard breaks across DOCX/PPTX/PDF exports.
+DEFAULT_ENABLED_INPUT_EXTENSIONS = ["hard_line_breaks"]
 DEFAULT_DISABLED_INPUT_EXTENSIONS = [
     "blank_before_header",  # https://pandoc.org/MANUAL.html#extension-blank_before_header
     "space_in_atx_header",  # https://pandoc.org/MANUAL.html#extension-space_in_atx_header

--- a/test/resources/line_breaks_md.md
+++ b/test/resources/line_breaks_md.md
@@ -1,0 +1,5 @@
+# Line Breaks
+
+🧪 First line
+🧭 Second line
+🔧 Third line

--- a/test/skills/test_md_to_docx.py
+++ b/test/skills/test_md_to_docx.py
@@ -1,3 +1,5 @@
+import zipfile
+
 from test_base import TestBase
 
 
@@ -23,3 +25,15 @@ class TestMdToDocx(TestBase):
 
         # Verify the output file is not empty
         self.verify_output_file(output_file)
+
+    def test_md_to_docx_preserves_single_newlines(self):
+        input_file = "test/resources/line_breaks_md.md"
+        output_file = "test_output/test_line_breaks.docx"
+
+        self.run_script("parser/cli_md_to_docx.py", input_file, output_file)
+        self.verify_output_file(output_file)
+
+        with zipfile.ZipFile(output_file) as docx_file:
+            document_xml = docx_file.read("word/document.xml").decode("utf-8")
+
+        self.assertIn("w:br", document_xml)

--- a/test/skills/test_md_to_html.py
+++ b/test/skills/test_md_to_html.py
@@ -12,3 +12,15 @@ class TestMdToHtml(TestBase):
 
         # Verify the output file is not empty
         self.verify_output_file(output_file)
+
+    def test_md_to_html_preserves_single_newlines(self):
+        input_file = "test/resources/line_breaks_md.md"
+        output_file = "test_output/test_line_breaks.html"
+
+        self.run_script("parser/cli_md_to_html.py", input_file, output_file)
+        self.verify_output_file(output_file)
+
+        with open(output_file, encoding="utf-8") as html_file:
+            html = html_file.read().lower()
+
+        self.assertIn("<br", html)


### PR DESCRIPTION
## What this fixes
Markdown files that rely on single newlines between visible lines, including emoji-led bullets and other non-dash bullet styles, were being rendered as one wrapped paragraph in exported documents. In DOCX/PPTX/PDF/HTML output, those lines were collapsing into spaces instead of staying as distinct lines.

That made valid Markdown look broken in exported documents, especially for lists and summary blocks that intentionally use line-separated entries rather than `-` bullets.

## What changed
- Enable Pandoc `hard_line_breaks` by default for DOCX/PPTX/PDF exports
- Enable `nl2br` in the HTML conversion path so HTML/PDF retain visible line breaks consistently
- Add regression tests that verify:
  - DOCX output contains hard breaks for line-separated Markdown
  - HTML output retains `<br>` elements for the same input
- Add a simple fixture with line-separated emoji-led lines to cover the real-world case

## Why this should be the default
The package already treats these inputs as valid Markdown. The problem was the export layer collapsing visible line separation during conversion. Making hard breaks the default preserves the author’s intended layout across the export paths and keeps Markdown Exporter usable for docs that are not written as dash-based bullet lists.

## Notes
- This applies to the installed CLI and command-driven usage as well, since they share the same export code paths
- I kept the change scoped to the conversion defaults rather than requiring users to change their source Markdown