### PR TITLE
refactor(text_utils): remove redundant contains_japanese and simplify normalize_line_breaks

### DIFF
--- a/md_exporter/services/svc_md_to_pdf.py
+++ b/md_exporter/services/svc_md_to_pdf.py
@@ -12,7 +12,7 @@ from typing import Literal
 from urllib.parse import urlparse
 
 from ..utils.markdown_utils import get_md_text
-from ..utils.text_utils import contains_chinese, contains_japanese, contains_korean, detect_cjk_language
+from ..utils.text_utils import contains_chinese, contains_japanese_kana, contains_korean, detect_cjk_language
 
 # Directory containing bundled Noto Sans CJK fonts (SIL OFL 1.1, see LICENSE there)
 FONTS_DIR = Path(__file__).resolve().parent.parent / "assets" / "fonts"
@@ -171,7 +171,7 @@ def convert_md_to_pdf(md_text: str, output_path: Path, is_strip_wrapper: bool = 
 
     processed_md = get_md_text(md_text, is_strip_wrapper=is_strip_wrapper)
     include_cjk_font = (
-        contains_chinese(processed_md) or contains_japanese(processed_md) or contains_korean(processed_md)
+        contains_chinese(processed_md) or contains_japanese_kana(processed_md) or contains_korean(processed_md)
     )
 
     # Match Microsoft Word 2013+ page defaults: A4 paper, 2.54cm top/bottom

--- a/md_exporter/utils/__init__.py
+++ b/md_exporter/utils/__init__.py
@@ -4,7 +4,7 @@ from .markdown_utils import convert_markdown_to_html, get_md_text, strip_markdow
 from .mimetype_utils import MimeType
 from .param_utils import get_md_text_from_tool_params, get_param_value
 from .table_utils import SUGGESTED_SHEET_NAME, extract_headings, parse_md_to_tables
-from .text_utils import contains_chinese, contains_japanese, normalize_line_breaks, remove_think_tags
+from .text_utils import contains_chinese, normalize_line_breaks, remove_think_tags
 
 __all__ = [
     # file_utils
@@ -26,7 +26,6 @@ __all__ = [
     "SUGGESTED_SHEET_NAME",
     # text_utils
     "contains_chinese",
-    "contains_japanese",
     "remove_think_tags",
     "normalize_line_breaks",
 ]

--- a/md_exporter/utils/text_utils.py
+++ b/md_exporter/utils/text_utils.py
@@ -10,9 +10,6 @@ CHINESE_CHAR_PATTERN = re.compile(r"[\u4e00-\u9fff]")
 # Regex pattern for matching Japanese kana (hiragana + katakana)
 JAPANESE_KANA_PATTERN = re.compile(r"[\u3040-\u309F\u30A0-\u30FF]")
 
-# Regex pattern for matching Japanese characters (legacy, includes kanji)
-JAPANESE_CHAR_PATTERN = re.compile(r"[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]")
-
 # Regex pattern for matching Hangul syllables
 HANGUL_PATTERN = re.compile(r"[\uAC00-\uD7AF]")
 
@@ -29,11 +26,6 @@ _SIMPLIFIED_SPECIFIC_CHARS = frozenset(
 def contains_chinese(text: str) -> bool:
     """Check if contains Chinese characters"""
     return bool(CHINESE_CHAR_PATTERN.search(text))
-
-
-def contains_japanese(text: str) -> bool:
-    """Check if contains Japanese characters"""
-    return bool(JAPANESE_CHAR_PATTERN.search(text))
 
 
 def contains_japanese_kana(text: str) -> bool:
@@ -78,6 +70,4 @@ def remove_think_tags(text: str) -> str:
 
 def normalize_line_breaks(text: str) -> str:
     """Normalize line breaks"""
-    if "\\n" in text:
-        text = text.replace("\\n", "\n")
-    return text
+    return text.replace("\\n", "\n")


### PR DESCRIPTION
## Summary

Small follow-up cleanup after the CJK font switch.

## Changes

- Removed <code>contains_japanese</code> and its regex, which duplicated <code>contains_chinese</code> for kanji and <code>contains_japanese_kana</code> for kana.
- Updated the CJK font trigger in <code>svc_md_to_pdf.py</code> to use <code>contains_japanese_kana</code> for pure-kana Japanese text.
- Removed the now-unused <code>contains_japanese</code> export from <code>md_exporter.utils.__init__</code>.
- Simplified <code>normalize_line_breaks</code> by removing the unnecessary pre-check before <code>replace</code>.

## Verification

- All 18 skill tests pass.
- Ruff format/check passes.