### PR TITLE
chore(deps): remove unused jinja2 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 dependencies = [
     "markdown>=3.10.3",
     "pandas[excel,html,xml]~=3.0.5",
-    "jinja2>=3.1.6",
     "pypandoc-binary~=1.17",
     "typst>=0.15.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,6 @@ name = "md-exporter"
 version = "3.8.0"
 source = { editable = "." }
 dependencies = [
-    { name = "jinja2" },
     { name = "markdown" },
     { name = "pandas", extra = ["excel", "html", "xml"] },
     { name = "pypandoc-binary" },
@@ -578,7 +577,6 @@ dify = [
 
 [package.metadata]
 requires-dist = [
-    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "markdown", specifier = ">=3.10.3" },
     { name = "pandas", extras = ["excel", "html", "xml"], specifier = "~=3.0.5" },
     { name = "pypandoc-binary", specifier = "~=1.17" },


### PR DESCRIPTION
No source code imports or uses jinja2, and no main/transitive dependency requires it directly. Remove the direct dependency from pyproject.toml and update uv.lock (jinja2 remains only as a transitive dependency of dify-plugin in the optional dify group).