### PR TITLE
fix: preserve <br> line breaks in xlsx table cells

### DIFF
--- a/md_exporter/services/svc_md_to_xlsx.py
+++ b/md_exporter/services/svc_md_to_xlsx.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import pandas as pd
+from openpyxl.styles import Alignment
 
 from ..utils.markdown_utils import get_md_text
 from ..utils.table_utils import SUGGESTED_SHEET_NAME, parse_md_to_tables
@@ -45,6 +46,14 @@ def convert_md_to_xlsx(
             for i, table in enumerate(tables):
                 sheet_name = table.attrs.get(SUGGESTED_SHEET_NAME, f"Sheet{i + 1}")
                 table.to_excel(writer, sheet_name=sheet_name, index=False, na_rep="")
+
+                worksheet = writer.sheets[sheet_name]
+                # Enable text wrapping for cells that contain line breaks
+                for row in worksheet.iter_rows():
+                    for cell in row:
+                        if cell.value and isinstance(cell.value, str) and "\n" in cell.value:
+                            cell.alignment = Alignment(wrap_text=True)
+
                 # Auto-fit column width if supported
                 if hasattr(writer.sheets[sheet_name], "autofit"):
                     writer.sheets[sheet_name].autofit(max_width=200)

--- a/md_exporter/utils/table_utils.py
+++ b/md_exporter/utils/table_utils.py
@@ -1,13 +1,17 @@
+import re
 from io import StringIO
 from logging import Logger
 
 import markdown
 import pandas as pd
 from bs4 import BeautifulSoup
+from pandas.api.types import is_string_dtype
 
 from .markdown_utils import strip_markdown_wrapper
 
 SUGGESTED_SHEET_NAME = "suggested_sheet_name"
+LINE_BREAK_PLACEHOLDER = "__MDEXPORTER_LINE_BREAK__"
+BR_TAG_PATTERN = re.compile(r"<br\s*/?>", re.IGNORECASE)
 
 
 def extract_headings(html_str: str, extract_headings_for_sheet_names: bool) -> list[str]:
@@ -26,6 +30,19 @@ def extract_headings(html_str: str, extract_headings_for_sheet_names: bool) -> l
     return headings
 
 
+def _replace_br_tags_with_placeholder(html_str: str) -> str:
+    """Replace <br> tags with a placeholder so pandas.read_html preserves line breaks."""
+    return BR_TAG_PATTERN.sub(LINE_BREAK_PLACEHOLDER, html_str)
+
+
+def _restore_line_breaks(table: pd.DataFrame) -> pd.DataFrame:
+    """Restore line break placeholders to actual newline characters in string columns."""
+    for col in table.columns:
+        if is_string_dtype(table[col]):
+            table[col] = table[col].astype(str).str.replace(LINE_BREAK_PLACEHOLDER, "\n", regex=False)
+    return table
+
+
 def parse_md_to_tables(
     md_text: str,
     force_value_to_str: bool = True,
@@ -39,6 +56,7 @@ def parse_md_to_tables(
             md_text = md_text.replace("|", "\n|", 1)
 
         html_str = markdown.markdown(text=md_text, extensions=["tables"])
+        html_str = _replace_br_tags_with_placeholder(html_str)
         tables: list[pd.DataFrame] = pd.read_html(StringIO(html_str), encoding="utf-8")
         headings: list[str] = extract_headings(html_str, extract_headings_for_sheet_names)
 
@@ -48,6 +66,7 @@ def parse_md_to_tables(
                 for col in table.columns:
                     if table[col].dtype not in {"object", "string"}:
                         table[col] = table[col].astype(str)
+            table = _restore_line_breaks(table)
             return table
 
         result_tables = []

--- a/test/resources/example_md_table_with_br.md
+++ b/test/resources/example_md_table_with_br.md
@@ -1,0 +1,4 @@
+| Name | Description |
+|------|-------------|
+| Item 1 | Line one<br>Line two |
+| Item 2 | Single line |

--- a/test/skills/test_md_to_xlsx.py
+++ b/test/skills/test_md_to_xlsx.py
@@ -1,3 +1,4 @@
+from openpyxl import load_workbook
 from test_base import TestBase
 
 
@@ -12,3 +13,35 @@ class TestMdToXlsx(TestBase):
 
         # Verify the output file is not empty
         self.verify_output_file(output_file)
+
+    def test_md_to_xlsx_preserves_br_line_breaks(self):
+        """Regression test for GitHub issues #77 and #65:
+        <br> tags inside Markdown table cells should become line breaks in XLSX cells."""
+        input_file = "test/resources/example_md_table_with_br.md"
+        output_file = "test_output/test_br.xlsx"
+
+        self.run_script("parser/cli_md_to_xlsx.py", input_file, output_file)
+        self.verify_output_file(output_file)
+
+        workbook = load_workbook(output_file)
+        worksheet = workbook.active
+        self.assertIsNotNone(worksheet, "Worksheet is empty")
+        assert worksheet is not None
+
+        # Locate the "Description" column
+        description_col: int | None = None
+        for col_idx, cell in enumerate(worksheet[1], start=1):
+            if cell.value == "Description":
+                description_col = col_idx
+                break
+        self.assertIsNotNone(description_col, "Description column not found")
+        assert description_col is not None
+
+        # Cell with <br> should contain a real newline and have wrap text enabled
+        item_1_description = worksheet.cell(row=2, column=description_col)
+        self.assertEqual(item_1_description.value, "Line one\nLine two")
+        self.assertTrue(item_1_description.alignment.wrap_text)
+
+        # Regular cell should not contain a newline
+        item_2_description = worksheet.cell(row=3, column=description_col)
+        self.assertEqual(item_2_description.value, "Single line")


### PR DESCRIPTION
## Description

Fixes #77 and #65. Markdown table cells containing `<br>` tags now correctly produce line breaks in generated XLSX files, with text wrapping enabled.

## Changes

- In `md_exporter/utils/table_utils.py`: replace `<br>` variants with an internal placeholder before `pandas.read_html`, then restore them as `\n` after parsing.
- In `md_exporter/services/svc_md_to_xlsx.py`: enable `wrap_text` alignment for any cell containing `\n`.
- Added regression test `test_md_to_xlsx_preserves_br_line_breaks` and test resource `example_md_table_with_br.md`.

## Testing

- [x] Ran `./dev/reformat.sh` (lint/format)
- [x] Ran `uv run pytest test/` and all tests pass (24 passed)
- [x] Added/updated tests for new behavior

## Checklist

- [x] Code follows project style (120 char line limit, type hints, `pathlib.Path`)
- [x] No secrets or credentials committed
- [x] Documentation updated if needed
