### PR TITLE
feat: add Julia and Rust support to md_to_codeblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,8 @@ Effortlessly extract code blocks from your Markdown and save them as individual 
 | Bash       | `.sh`          | Java       | `.java`        |
 | JSON       | `.json`        | PHP        | `.php`         |
 | XML        | `.xml`         | Markdown   | `.md`          |
-| SVG        | `.svg`         |            |                |
+| SVG        | `.svg`         | Julia      | `.jl`          |
+| Rust       | `.rs`          |            |                |
 
 ![Code Block Example 1](https://raw.githubusercontent.com/bowenliang123/markdown-exporter/main/_assets/screenshots/usage_md_to_codeblock_2.png)
 

--- a/md_exporter/services/svc_md_to_codeblock.py
+++ b/md_exporter/services/svc_md_to_codeblock.py
@@ -40,6 +40,8 @@ MIME_TYPE_MAP = {
     "yaml": "text/yaml",
     "php": "application/x-httpd-php",
     "java": "text/x-java-source",
+    "julia": "text/x-julia",
+    "rust": "text/x-rust",
 }
 
 SUFFIX_MAP = {
@@ -58,6 +60,8 @@ SUFFIX_MAP = {
     "ruby": ".rb",
     "php": ".php",
     "java": ".java",
+    "julia": ".jl",
+    "rust": ".rs",
     "js": ".js",
 }
 

--- a/md_exporter/utils/mimetype_utils.py
+++ b/md_exporter/utils/mimetype_utils.py
@@ -9,6 +9,7 @@ class MimeType(StrEnum):
     HTML = "text/html"
     JS = "text/javascript"
     JAVA = "text/x-java-source"
+    JL = "text/x-julia"
     JSON = "application/json"
     LATEX = "application/x-tex"
     MD = "text/markdown"
@@ -17,6 +18,7 @@ class MimeType(StrEnum):
     PNG = "image/png"
     PPTX = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
     PY = "text/x-python"
+    RS = "text/x-rust"
     RST = "text/prs.fallenstein.rst"
     RUBY = "text/x-ruby"
     TXT = "text/plain"
@@ -42,6 +44,7 @@ class MimeType(StrEnum):
             cls.HTML: ".html",
             cls.JS: ".js",
             cls.JAVA: ".java",
+            cls.JL: ".jl",
             cls.JSON: ".json",
             cls.LATEX: ".tex",
             cls.MD: ".md",
@@ -50,6 +53,7 @@ class MimeType(StrEnum):
             cls.PNG: ".png",
             cls.PPTX: ".pptx",
             cls.PY: ".py",
+            cls.RS: ".rs",
             cls.RST: ".rst",
             cls.RUBY: ".rb",
             cls.TXT: ".txt",

--- a/test/resources/example_md_codeblock_julia_rust.md
+++ b/test/resources/example_md_codeblock_julia_rust.md
@@ -1,0 +1,13 @@
+# Julia and Rust Code Blocks
+
+```julia
+function hello()
+    println("Hello from Julia")
+end
+```
+
+```rust
+fn main() {
+    println!("Hello from Rust");
+}
+```

--- a/test/skills/test_md_to_codeblock.py
+++ b/test/skills/test_md_to_codeblock.py
@@ -1,3 +1,5 @@
+import os
+
 from test_base import TestBase
 
 
@@ -12,3 +14,17 @@ class TestMdToCodeblock(TestBase):
 
         # Verify the output directory is not empty
         self.verify_output_dir(output_dir)
+
+    def test_md_to_codeblock_julia_and_rust(self):
+        """Regression test for GitHub issue #168:
+        Julia and Rust code blocks should be extracted with .jl and .rs suffixes."""
+        input_file = "test/resources/example_md_codeblock_julia_rust.md"
+        output_dir = "test_output/codeblocks_julia_rust"
+
+        self.run_script("parser/cli_md_to_codeblock.py", input_file, output_dir)
+        self.verify_output_dir(output_dir)
+
+        created_files = sorted(os.listdir(output_dir))
+        self.assertEqual(len(created_files), 2)
+        self.assertTrue(any(name.endswith(".jl") for name in created_files), f"No .jl file found in {created_files}")
+        self.assertTrue(any(name.endswith(".rs") for name in created_files), f"No .rs file found in {created_files}")

--- a/tools/md_to_codeblock/md_to_codeblock.py
+++ b/tools/md_to_codeblock/md_to_codeblock.py
@@ -77,6 +77,10 @@ class MarkdownToCodeblockTool(Tool):
                         mime_type = MimeType.PHP
                     elif suffix == ".java":
                         mime_type = MimeType.JAVA
+                    elif suffix == ".jl":
+                        mime_type = MimeType.JL
+                    elif suffix == ".rs":
+                        mime_type = MimeType.RS
 
                     yield self.create_blob_message(
                         blob=file_path.read_bytes(),


### PR DESCRIPTION
## Description

Closes #168. Adds first-class support for extracting Julia and Rust code blocks in the `md_to_codeblock` tool, and documents them in the README.

## Changes

- Added `julia` / `rust` mappings to `MIME_TYPE_MAP` and `SUFFIX_MAP` in `md_exporter/services/svc_md_to_codeblock.py`.
- Added `JL` and `RS` MIME types to `md_exporter/utils/mimetype_utils.py` with corresponding extensions.
- Added `.jl` / `.rs` suffix handling in `tools/md_to_codeblock/md_to_codeblock.py` so Dify plugin returns the correct MIME type.
- Updated README supported-languages table to include Julia and Rust.
- Added regression test `test_md_to_codeblock_julia_and_rust` and test resource.

## Testing

- [x] Ran `./dev/reformat.sh` (lint/format)
- [x] Ran `uv run pytest test/` and all tests pass (25 passed)
- [x] Added/updated tests for new behavior

## Checklist

- [x] Code follows project style (120 char line limit, type hints, `pathlib.Path`)
- [x] No secrets or credentials committed
- [x] Documentation updated if needed
