### PR TITLE
fix: replace typst horizontalrule removed in 0.13+

### DIFF
--- a/md_exporter/utils/typst_utils.py
+++ b/md_exporter/utils/typst_utils.py
@@ -210,6 +210,10 @@ def compile_markdown_with_typst(
         work_path = Path(work_dir)
         processed_md = _inline_remote_images(processed_md, work_path)
         typst_body = convert_text(source=processed_md, format="markdown", to="typst")
+        # Typst 0.13+ removed the `horizontalrule` function (renamed to `line`).
+        # Pandoc 3.x still emits `#horizontalrule` for markdown thematic breaks.
+        typst_body = typst_body.replace("#horizontalrule()", "#line(length: 100%)")
+        typst_body = typst_body.replace("#horizontalrule", "#line(length: 100%)")
 
         if include_cjk_font:
             doc_lang = detect_cjk_language(processed_md)


### PR DESCRIPTION
## Problem

`md_to_svg` / `md_to_png` / `md_to_pdf` fail on Markdown containing thematic breaks (`---`):

```
Error: Failed to convert to SVG - unknown variable: horizontalrule
```

pandoc 3.x converts `---` to Typst's `#horizontalrule`, but that function was deprecated in Typst 0.12 and **removed in 0.13+** (renamed to `line`). This project uses the typst 0.15 Python binding.

## Fix

Rewrite pandoc's `#horizontalrule` output to `#line(length: 100%)` after the `markdown → typst` conversion in `compile_markdown_with_typst` (typst_utils.py:213-216), covering all three typst-backed tools at once.

## Verification

- Converted this repo's README.md (824 lines) to SVG (23 pages), PNG, and PDF (23 pages) successfully
- `uv run pytest test/skills/test_md_to_png.py test/skills/test_md_to_svg.py test/skills/test_md_to_pdf.py` → 8 passed
- `./dev/reformat.sh` → all checks passed