### PR TITLE
fix(plugin-publish): read README from workspace for changelog extraction

### DIFF
--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -119,9 +119,10 @@ jobs:
           git commit -m "bump ${{ steps.get_basic_info.outputs.plugin_name }} plugin to version ${{ steps.get_basic_info.outputs.version }}"
 
           # Extract this version's changelog bullets from README for the PR body
-          # (rewrite issue refs like (#172) to point at the source repo, not dify-plugins)
+          # (README.md lives in $GITHUB_WORKSPACE, not the dify-plugins checkout;
+          # rewrite issue refs like (#172) to point at the source repo, not dify-plugins)
           REPO_SLUG="${REPO#https://github.com/}"
-          WHAT_CHANGED=$(awk "/^- ${{ steps.get_basic_info.outputs.version }}$/{f=1;next} /^- [0-9]+\.[0-9]+\.[0-9]+$/{f=0} f" README.md | sed -e 's/^[[:space:]]*//' -e "s|(#|(${REPO_SLUG}#|g")
+          WHAT_CHANGED=$(awk "/^- ${{ steps.get_basic_info.outputs.version }}$/{f=1;next} /^- [0-9]+\.[0-9]+\.[0-9]+$/{f=0} f" "$GITHUB_WORKSPACE/README.md" | sed -e 's/^[[:space:]]*//' -E -e "s|#([0-9]+)|${REPO_SLUG}#\1|g")
           if [ -z "$WHAT_CHANGED" ]; then
             WHAT_CHANGED="- Bump ${{ steps.get_basic_info.outputs.plugin_name }} to ${{ steps.get_basic_info.outputs.version }}."
           fi


### PR DESCRIPTION
## Summary

The changelog extraction in the plugin-publish workflow ran after `cd dify-plugins`, so `README.md` resolved to the target repo's README instead of the plugin's — the awk match never fired and every submission PR got the fallback one-liner (e.g. langgenius/dify-plugins#2874).

- Read `$GITHUB_WORKSPACE/README.md` instead of `README.md`
- Rewrite all `#N` issue refs to the source repo (was: only `(#N`, leaving `#187` bare in multi-ref bullets)

Verified the extraction pipeline locally against the 4.0.0 changelog: produces all six bullets with correct repo-qualified issue links.