### PR TITLE
docs: emphasize emoji rendering fix in 4.0.0 changelog entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ Releases are available at:
   - Introduce `md_to_svg` and `md_to_png` tools for converting Markdown to images (#179)
   - Fix image display issues in README by unifying screenshot sizes and removing unreferenced assets (#180 #187)
   - Fix PDF/PNG/SVG conversion failure on thematic breaks (`---`) by replacing `#horizontalrule` removed in Typst 0.13+ (#186)
-  - Bundle the Twemoji Mozilla emoji font in `md_to_pdf`, `md_to_png` and `md_to_svg` tools, fixing blank emoji output on systems without emoji fonts (#191)
+  - Fix emoji rendering failure (tofu boxes) in `md_to_pdf`, `md_to_png` and `md_to_svg` tools on systems without emoji fonts by bundling the Twemoji Mozilla emoji font (#191)
   - Fix `<br>` line breaks being lost in table cells in `md_to_xlsx` tool (#183)
 
 - 3.8.0


### PR DESCRIPTION
## Description

Reword the #191 changelog entry to lead with the user-visible fix: emoji rendering failure (tofu boxes) in `md_to_pdf`, `md_to_png` and `md_to_svg` on systems without emoji fonts.