### PR TITLE
fix: render CJK bold in md_to_pdf/png/svg by bundling Noto Sans CJK Bold weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ Releases are available at:
   - Fix image display issues in README by unifying screenshot sizes and removing unreferenced assets (#180 #187)
   - Fix PDF/PNG/SVG conversion failure on thematic breaks (`---`) by replacing `#horizontalrule` removed in Typst 0.13+ (#186)
   - Fix emoji rendering failure (tofu boxes) in `md_to_pdf`, `md_to_png` and `md_to_svg` tools on systems without emoji fonts by bundling the Twemoji Mozilla emoji font (#191)
+  - Fix bold text (headings, `**strong**`) rendering without emphasis in `md_to_pdf`, `md_to_png` and `md_to_svg` by bundling the Noto Sans CJK Bold weight (#193)
   - Fix `<br>` line breaks being lost in table cells in `md_to_xlsx` tool (#183)
 
 - 3.8.0

--- a/md_exporter/assets/fonts/LICENSE
+++ b/md_exporter/assets/fonts/LICENSE
@@ -1,7 +1,7 @@
 Bundled fonts and their licenses:
 
-- NotoSansCJK-Regular.ttc: Noto Sans CJK SC/TC/JP/KR, SIL Open Font
-  License 1.1 (full text below).
+- NotoSansCJK-Regular.ttc and NotoSansCJK-Bold.ttc: Noto Sans CJK
+  SC/TC/JP/KR, SIL Open Font License 1.1 (full text below).
 - Twemoji.Mozilla.ttf: Twemoji graphics by Twitter, Inc. and other
   contributors, licensed under CC-BY 4.0
   (https://creativecommons.org/licenses/by/4.0/). Font built by Mozilla

--- a/test/skills/test_md_to_pdf.py
+++ b/test/skills/test_md_to_pdf.py
@@ -47,6 +47,31 @@ class TestMdToPdf(TestBase):
         self.assertIn(b"NotoSansCJKjp-Regular", pdf_bytes, "JP font is not used")
         self.assertIn(b"NotoSansCJKkr-Regular", pdf_bytes, "KR font is not used")
 
+    def test_md_to_pdf_cjk_bold(self):
+        # Bold CJK text must use the embedded Noto Sans CJK Bold weight
+        # (previously only Regular was bundled, so bold silently rendered as Regular)
+        input_file = "test_output/cjk_bold_input.md"
+        output_file = "test_output/test_cjk_bold.pdf"
+
+        content = """# 加粗标题测试
+
+普通文本与**加粗文本**对比。
+
+**整段加粗的中文内容，用于验证 Bold 字重。**
+"""
+        with open(input_file, "w", encoding="utf-8") as f:
+            f.write(content)
+        self.register_output(input_file)
+
+        self.run_script("parser/cli_md_to_pdf.py", input_file, output_file)
+        self.verify_output_file(output_file)
+
+        with open(output_file, "rb") as f:
+            pdf_bytes = f.read()
+        has_font_stream = b"FontFile2" in pdf_bytes or b"FontFile3" in pdf_bytes
+        self.assertTrue(has_font_stream, "CJK font is not embedded in the PDF")
+        self.assertIn(b"NotoSansCJKsc-Bold", pdf_bytes, "Bold SC font is not used")
+
     def test_md_to_pdf_cjk_paragraph_level_fonts(self):
         # Mixed CJK document should use region-specific fonts per paragraph
         input_file = "test_output/mixed_cjk_input.md"


### PR DESCRIPTION
## Description

The bundled Noto Sans CJK font was Regular-only (`NotoSansCJK-Regular.ttc`), and Typst does not synthesize bold. As a result, headings and `**strong**` emphasis silently rendered at Regular weight in CJK documents — including Latin text inside CJK documents, because `#set text` locks the whole font stack to Noto CJK.

## Changes

- Add `NotoSansCJK-Bold.ttc` to `assets/fonts` (family names match Regular, so Typst automatically selects weight 700 for bold — no code change needed)
- Add regression test `test_md_to_pdf_cjk_bold` asserting `NotoSansCJKsc-Bold` is embedded in the PDF
- Document the added font in `assets/fonts/LICENSE`
- README changelog entry

## Testing

- [x] Ran `./dev/reformat.sh` (lint/format)
- [x] Ran `uv run pytest test/skills` and all tests pass (27 passed)
- [x] Added regression test for bold CJK embedding
- Manually verified (pixel ink density): bold CJK +50%, bold Latin-in-CJK +54%, vs. before where bold and regular were byte-identical

## Checklist

- [x] Code follows project style
- [x] No secrets or credentials committed
- [x] Documentation updated